### PR TITLE
fix(ci): give claude-code-action a prompt instead of a fake `agent` input

### DIFF
--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -76,12 +76,27 @@ jobs:
           # (generated locally with `claude setup-token`, stored as a repo secret).
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.OPENPX_BOT_TOKEN }}
-          agent: orchestrator
-          # The orchestrator reads .drift/drift.json (if present) plus the
-          # GitHub event payload from $GITHUB_EVENT_PATH. Its prompt branches
-          # on event type — see .claude/agents/orchestrator.md.
-          claude_args: |
-            --max-turns 30
+          # The action expects an explicit prompt to know what to do on
+          # workflow_dispatch / schedule / pull_request events (no @-mention
+          # to detect). Tell it to load the orchestrator agent definition
+          # and follow it.
+          prompt: |
+            Read `.claude/agents/orchestrator.md` and follow those
+            instructions exactly. The triggering GitHub event payload is
+            available at `$GITHUB_EVENT_PATH` (event type: `${{ github.event_name }}`,
+            action: `${{ github.event.action }}`).
+
+            The drift artifact (if present from the most recent docs-drift
+            workflow run) is at `./.drift/drift.json`.
+
+            Branch on the event type per the orchestrator's three roles:
+            - `schedule` / `workflow_dispatch` → weekly drift cycle
+            - `issues` / `issue_comment` → issue triage (workflow `if:` already
+              gated for admin association)
+            - `pull_request` (closed + merged) → changelog append
+
+            End with the standard handoff message from `.claude/agents/HANDOFF.md`.
+          claude_args: --max-turns 30
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}


### PR DESCRIPTION
## What changed

The orchestrator's CI step was wired with \`agent: orchestrator\`, which isn't a valid input on \`anthropics/claude-code-action@v1\`. The action ignored it, found no trigger phrase / @-mention / prompt, logged \`Trigger result: false → No trigger found, skipping remaining steps\`, and exited in 16-19s.

Replace with a \`prompt:\` that tells Claude to load \`.claude/agents/orchestrator.md\` and follow it. Event payload + drift artifact path + event type are passed through.

## Why

Both agent-tick.yml runs (the cron-equivalent dispatch from \`just maintain\` and the auto-fired PR-merge-changelog run) returned green but did nothing. We need them to actually do work.

## Files

- \`.github/workflows/agent-tick.yml\`: ±21 lines

## Tests

Workflow change only — no Rust tests affected. The actual verification is firing the workflow after merge:

\`\`\`
just maintain
gh run watch
\`\`\`

The orchestrator should now read its agent file, branch on the event, and either dispatch maintainers / parity-analyst (cron path), triage the issue (issue path), or append to docs/changelog.mdx (PR-merge path).

## Review focus

1. The \`prompt:\` block — does it give the orchestrator enough context (event type, action, paths) to branch correctly?
2. \`claude_args: --max-turns 30\` — adequate budget for a full weekly cycle? Can be raised later if the orchestrator hits the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)