### PR TITLE
fix(ci): bypass per-tool permission prompts for orchestrator

### DIFF
--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -96,7 +96,12 @@ jobs:
             - `pull_request` (closed + merged) → changelog append
 
             End with the standard handoff message from `.claude/agents/HANDOFF.md`.
-          claude_args: --max-turns 30
+          # bypassPermissions: skip per-tool permission prompts (which would
+          # otherwise block every gh pr create / Edit / Write the orchestrator
+          # makes). The real safety net is CODEOWNERS + branch protection +
+          # contracts_test + manifest_coverage — not per-tool prompts.
+          # Agent prompts forbid destructive ops (merge, force-push, --no-verify).
+          claude_args: --max-turns 30 --permission-mode bypassPermissions
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}


### PR DESCRIPTION
## What changed

Adds \`--permission-mode bypassPermissions\` to the orchestrator's \`claude_args\` in \`agent-tick.yml\`.

## Why

The previous run executed for 5m33s, ran 36 turns, cost ~\$0.97, and **opened zero PRs/issues** because 18 of those 36 turns were permission denials. The action's default per-tool prompts blocked every \`gh pr create\`, \`Edit\`, and \`Write\` the orchestrator tried.

\`\`\`json
{
  \"duration_ms\": 308238,
  \"num_turns\": 36,
  \"permission_denials_count\": 18
}
\`\`\`

## Safety net is unchanged

Per-tool prompts were never the real safety net. These still gate everything that matters:

- \`.github/CODEOWNERS\` — funds-moving Polymarket files (\`clob.rs\`, \`ctf.rs\`, \`relayer.rs\`, \`swap.rs\`, \`signer.rs\`, \`approvals.rs\`), \`kalshi/auth.rs\`, \`engine/core/\`, \`engine/sdk/\`, \`.github/\`, release configs, credentials all require explicit human review.
- \`maintenance/tests/manifest_coverage.rs\` — CI fails if exchange.rs reads a JSON key not declared in the manifest or allowlist.
- \`maintenance/tests/contracts_test.rs\` — CI fails on contract-address drift.
- Agent prompts (in \`.claude/agents/*.md\`) explicitly forbid \`gh pr merge\`, force-push, and \`--no-verify\`.
- Branch protection (when applied) requires CODEOWNERS approval and all status checks green before merge.

The orchestrator is now allowed to draft and propose; humans still approve and merge.

## Files

- \`.github/workflows/agent-tick.yml\`: ±6 lines

## Tests

Workflow change. Verify after merge:

\`\`\`
just maintain
gh run watch
\`\`\`

Expected outcome: the orchestrator finishes with \`permission_denials_count: 0\` (or near-zero), and at minimum updates \`docs/parity/STATUS.md\` (the parity-analyst's first-run output). If there's any upstream drift, it should also open one or more maintainer PRs.

## Review focus

1. \`--permission-mode bypassPermissions\` — comfortable with this given the safety nets above? Alternative: \`additional_permissions\` input on the action with an explicit tool allowlist (more granular, more fragile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)