### PR TITLE
chore(workflow): bump matrix max-parallel from 4 to 8

### DIFF
--- a/.github/workflows/agent-tick.yml
+++ b/.github/workflows/agent-tick.yml
@@ -156,9 +156,10 @@ jobs:
     strategy:
       fail-fast: false
       # Cap parallelism to keep within Anthropic API rate limits and to
-      # avoid 5+ simultaneous CI runs hammering the runner pool. Backfills
-      # of 50+ entries simply queue.
-      max-parallel: 4
+      # avoid too many simultaneous CI runs hammering the runner pool.
+      # 8 halves the wave count for full 15-entry backfill chunks (was 4)
+      # while staying inside subscription rate limits in practice.
+      max-parallel: 8
       matrix:
         item: ${{ fromJson(needs.classify.outputs.dispatches) }}
 


### PR DESCRIPTION
## Summary
- Halves the wave count for a full 15-entry backfill chunk: 10-12 specialists in ~2 waves instead of ~3.
- Previous run [25028709715](https://github.com/openpx-trade/openpx/actions/runs/25028709715) shows the cost: 10 specialists × max-parallel=4 took ~60 min of wave time on top of the 12 min classify job. Bumping to 8 saves ~20 min wallclock per backfill chunk.
- Stays within Claude Max subscription rate limits in practice (specialists are mostly I/O-bound on cargo / sync-all, not on Anthropic calls).

## Files
- `.github/workflows/agent-tick.yml` — `max-parallel: 4 → 8`, comment refreshed.

## Test plan
- [ ] After merge, run `just backfill 2026-02-01` (or wait for the next daily tick) and confirm up to 8 specialists run concurrently in the matrix.
- [ ] Watch for rate-limit / 429 noise in any specialist log; if it shows up consistently, drop back to 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)