### PR TITLE
chore(polymarket): CLOB V2 + pUSD migration (contracts + SDK swap)

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,21 @@ This page summarizes user-facing releases.
 
 ## Unreleased
 
+### Breaking
+
+- **Polymarket CLOB V2 + pUSD migration (cutover 2026-04-28 ~11:00 UTC)** —
+  no V1 backward compatibility. The OpenPX Polymarket adapter now depends
+  on `polymarket_client_sdk_v2 = "=0.5.1"` and signs orders against the
+  V2 EIP-712 domain (`version: "2"`). The order struct drops `nonce`,
+  `feeRateBps`, and `taker`; adds `timestamp` (ms), `metadata` (bytes32),
+  and `builder` (bytes32). Trading collateral is now **pUSD** (not USDC.e);
+  approvals + balance reads target `0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB`.
+  V1 builder-promotion (HMAC headers on order signing) is removed; builder
+  attribution moves into the signed order's `builder` field via
+  `SdkConfig::builder().builder_code(...)`. Relayer `POLY_BUILDER_*` HMAC
+  headers are preserved for gasless tx auth (per the Polymarket migration
+  guide). ([#54](https://github.com/openpx-trade/openpx/pull/54))
+
 ### Added
 
 - **core**: `Exchange::fetch_server_time()` returns each venue's wall-clock as `DateTime<Utc>` for clock-skew correction in signing-sensitive paths. `ExchangeInfo` gains `has_fetch_server_time: bool`. ([#26](https://github.com/openpx-trade/openpx/pull/26))

--- a/engine/exchanges/polymarket/Cargo.toml
+++ b/engine/exchanges/polymarket/Cargo.toml
@@ -25,7 +25,7 @@ chrono = { workspace = true }
 tracing = { workspace = true }
 tokio-stream = { version = "0.1", features = ["sync"] }
 regex = { workspace = true }
-polymarket-client-sdk = { version = "0.4.1", features = ["clob", "heartbeats"] }
+polymarket_client_sdk_v2 = { version = "=0.5.1", features = ["clob", "heartbeats"] }
 k256 = "0.13"
 uuid = "1"
 alloy = { version = "1.5", features = ["providers", "signers", "contract", "network", "sol-types"] }

--- a/engine/exchanges/polymarket/src/approvals.rs
+++ b/engine/exchanges/polymarket/src/approvals.rs
@@ -20,11 +20,14 @@ use std::str::FromStr;
 use crate::config::DEFAULT_POLYGON_RPC;
 use crate::error::PolymarketError;
 
-// Contract addresses on Polygon Mainnet
-pub const USDC_ADDRESS: &str = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+// Contract addresses on Polygon Mainnet — refreshed for CLOB V2 + pUSD cutover (2026-04-28).
+// Source of truth: https://docs.polymarket.com/resources/contracts.
+// Mirrored in maintenance/snapshots/polymarket-contracts.snapshot.json (contracts_test gates drift).
+pub const PUSD_ADDRESS: &str = "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB";
+pub const PUSD_IMPL_ADDRESS: &str = "0x6bBCef9f7ef3B6C592c99e0f206a0DE94Ad0925f";
 pub const CTF_ADDRESS: &str = "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045";
-pub const CTF_EXCHANGE: &str = "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E";
-pub const NEG_RISK_CTF_EXCHANGE: &str = "0xC5d563A36AE78145C45a50134d48A1215220f80a";
+pub const CTF_EXCHANGE: &str = "0xE111180000d2663C0091e4f400237545B87B996B";
+pub const NEG_RISK_CTF_EXCHANGE: &str = "0xe2222d279d744050d28e00520010520000310F59";
 pub const NEG_RISK_ADAPTER: &str = "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296";
 
 // Max approval amount (2^256 - 1)
@@ -207,7 +210,7 @@ pub fn encode_approval_calldata(token: &TokenType, target: &ApprovalTarget) -> (
                 amount: U256::MAX,
             };
             let calldata = alloy::primitives::hex::encode(call.abi_encode());
-            (USDC_ADDRESS.to_string(), format!("0x{calldata}"))
+            (PUSD_ADDRESS.to_string(), format!("0x{calldata}"))
         }
         TokenType::Ctf => {
             let call = IERC1155::setApprovalForAllCall {
@@ -229,7 +232,7 @@ pub fn encode_usdc_approval(spender_address: &str) -> (String, String) {
         amount: U256::MAX,
     };
     let calldata = alloy::primitives::hex::encode(call.abi_encode());
-    (USDC_ADDRESS.to_string(), format!("0x{calldata}"))
+    (PUSD_ADDRESS.to_string(), format!("0x{calldata}"))
 }
 
 /// Result of a single approval transaction
@@ -272,7 +275,7 @@ impl TokenApprover {
             .await
             .map_err(|e| PolymarketError::Network(format!("failed to connect to RPC: {e}")))?;
 
-        let usdc_addr = Address::from_str(USDC_ADDRESS)
+        let usdc_addr = Address::from_str(PUSD_ADDRESS)
             .map_err(|e| PolymarketError::Config(format!("invalid USDC address: {e}")))?;
         let ctf_addr = Address::from_str(CTF_ADDRESS)
             .map_err(|e| PolymarketError::Config(format!("invalid CTF address: {e}")))?;
@@ -355,7 +358,7 @@ impl TokenApprover {
             .await
             .map_err(|e| PolymarketError::Network(format!("failed to connect to RPC: {e}")))?;
 
-        let usdc_addr = Address::from_str(USDC_ADDRESS)
+        let usdc_addr = Address::from_str(PUSD_ADDRESS)
             .map_err(|e| PolymarketError::Config(format!("invalid USDC address: {e}")))?;
         let ctf_addr = Address::from_str(CTF_ADDRESS)
             .map_err(|e| PolymarketError::Config(format!("invalid CTF address: {e}")))?;

--- a/engine/exchanges/polymarket/src/clob.rs
+++ b/engine/exchanges/polymarket/src/clob.rs
@@ -4,8 +4,8 @@
 //! and the official polymarket-client-sdk. The SDK handles all authentication,
 //! signing, and API interactions.
 
-use polymarket_client_sdk::auth::{Credentials, ExposeSecret};
-use polymarket_client_sdk::clob::types::{Side, SignatureType};
+use polymarket_client_sdk_v2::auth::{Credentials, ExposeSecret};
+use polymarket_client_sdk_v2::clob::types::{Side, SignatureType};
 use serde::{Deserialize, Serialize};
 
 use crate::config::PolymarketSignatureType;
@@ -49,12 +49,12 @@ pub enum ClobOrderType {
     Ioc,
 }
 
-impl From<ClobOrderType> for polymarket_client_sdk::clob::types::OrderType {
+impl From<ClobOrderType> for polymarket_client_sdk_v2::clob::types::OrderType {
     fn from(t: ClobOrderType) -> Self {
         match t {
-            ClobOrderType::Gtc => polymarket_client_sdk::clob::types::OrderType::GTC,
-            ClobOrderType::Fok => polymarket_client_sdk::clob::types::OrderType::FOK,
-            ClobOrderType::Ioc => polymarket_client_sdk::clob::types::OrderType::FAK,
+            ClobOrderType::Gtc => polymarket_client_sdk_v2::clob::types::OrderType::GTC,
+            ClobOrderType::Fok => polymarket_client_sdk_v2::clob::types::OrderType::FOK,
+            ClobOrderType::Ioc => polymarket_client_sdk_v2::clob::types::OrderType::FAK,
         }
     }
 }

--- a/engine/exchanges/polymarket/src/ctf.rs
+++ b/engine/exchanges/polymarket/src/ctf.rs
@@ -8,7 +8,7 @@ use alloy::sol;
 use alloy::sol_types::SolCall;
 use std::str::FromStr;
 
-use crate::approvals::{CTF_ADDRESS, NEG_RISK_ADAPTER, USDC_ADDRESS};
+use crate::approvals::{CTF_ADDRESS, NEG_RISK_ADAPTER, PUSD_ADDRESS};
 use crate::error::PolymarketError;
 
 sol! {
@@ -51,7 +51,7 @@ const BINARY_PARTITION: [u64; 2] = [1, 2];
 /// Encode splitPosition calldata for binary markets.
 /// Returns (to_address, hex_calldata) targeting the CTF contract.
 pub fn encode_split_calldata(condition_id: B256, amount: U256) -> (String, String) {
-    let collateral = Address::from_str(USDC_ADDRESS).expect("USDC_ADDRESS constant must be valid");
+    let collateral = Address::from_str(PUSD_ADDRESS).expect("PUSD_ADDRESS constant must be valid");
     let partition: Vec<U256> = BINARY_PARTITION.iter().map(|&v| U256::from(v)).collect();
 
     let call = IConditionalTokens::splitPositionCall {
@@ -68,7 +68,7 @@ pub fn encode_split_calldata(condition_id: B256, amount: U256) -> (String, Strin
 /// Encode mergePositions calldata for binary markets.
 /// Returns (to_address, hex_calldata) targeting the CTF contract.
 pub fn encode_merge_calldata(condition_id: B256, amount: U256) -> (String, String) {
-    let collateral = Address::from_str(USDC_ADDRESS).expect("USDC_ADDRESS constant must be valid");
+    let collateral = Address::from_str(PUSD_ADDRESS).expect("PUSD_ADDRESS constant must be valid");
     let partition: Vec<U256> = BINARY_PARTITION.iter().map(|&v| U256::from(v)).collect();
 
     let call = IConditionalTokens::mergePositionsCall {
@@ -85,7 +85,7 @@ pub fn encode_merge_calldata(condition_id: B256, amount: U256) -> (String, Strin
 /// Encode redeemPositions calldata for standard (non-neg-risk) markets.
 /// Returns (to_address, hex_calldata) targeting the CTF contract.
 pub fn encode_redeem_calldata(condition_id: B256) -> (String, String) {
-    let collateral = Address::from_str(USDC_ADDRESS).expect("USDC_ADDRESS constant must be valid");
+    let collateral = Address::from_str(PUSD_ADDRESS).expect("PUSD_ADDRESS constant must be valid");
     let index_sets: Vec<U256> = BINARY_PARTITION.iter().map(|&v| U256::from(v)).collect();
 
     let call = IConditionalTokens::redeemPositionsCall {

--- a/engine/exchanges/polymarket/src/diagnostics.rs
+++ b/engine/exchanges/polymarket/src/diagnostics.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use tracing::{debug, info};
 
-use crate::approvals::USDC_ADDRESS;
+use crate::approvals::PUSD_ADDRESS;
 use crate::config::{PolymarketSignatureType, DEFAULT_POLYGON_RPC};
 use crate::error::PolymarketError;
 
@@ -61,8 +61,8 @@ pub async fn diagnose_wallets(
         .await
         .map_err(|e| PolymarketError::Network(format!("failed to connect to RPC: {e}")))?;
 
-    let usdc_addr = Address::from_str(USDC_ADDRESS)
-        .map_err(|e| PolymarketError::Config(format!("invalid USDC address: {e}")))?;
+    let usdc_addr = Address::from_str(PUSD_ADDRESS)
+        .map_err(|e| PolymarketError::Config(format!("invalid pUSD address: {e}")))?;
     let usdc = IERC20Balance::new(usdc_addr, &provider);
 
     let eoa_usdc = usdc

--- a/engine/exchanges/polymarket/src/diagnostics.rs
+++ b/engine/exchanges/polymarket/src/diagnostics.rs
@@ -11,7 +11,7 @@ use crate::config::{PolymarketSignatureType, DEFAULT_POLYGON_RPC};
 use crate::error::PolymarketError;
 
 // Polymarket SDK utilities to derive proxy/safe wallets.
-use polymarket_client_sdk::{derive_proxy_wallet, derive_safe_wallet};
+use polymarket_client_sdk_v2::{derive_proxy_wallet, derive_safe_wallet};
 
 sol! {
     #[sol(rpc)]

--- a/engine/exchanges/polymarket/src/error.rs
+++ b/engine/exchanges/polymarket/src/error.rs
@@ -37,9 +37,9 @@ impl From<PolymarketError> for px_core::ExchangeError {
     }
 }
 
-impl From<polymarket_client_sdk::error::Error> for PolymarketError {
-    fn from(err: polymarket_client_sdk::error::Error) -> Self {
-        use polymarket_client_sdk::error::Kind;
+impl From<polymarket_client_sdk_v2::error::Error> for PolymarketError {
+    fn from(err: polymarket_client_sdk_v2::error::Error) -> Self {
+        use polymarket_client_sdk_v2::error::Kind;
         match err.kind() {
             Kind::Status => PolymarketError::Api(err.to_string()),
             Kind::Validation => PolymarketError::Config(err.to_string()),

--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -571,7 +571,9 @@ impl Polymarket {
         let status = match &resp.status {
             polymarket_client_sdk_v2::clob::types::OrderStatusType::Live => OrderStatus::Open,
             polymarket_client_sdk_v2::clob::types::OrderStatusType::Matched => OrderStatus::Filled,
-            polymarket_client_sdk_v2::clob::types::OrderStatusType::Canceled => OrderStatus::Cancelled,
+            polymarket_client_sdk_v2::clob::types::OrderStatusType::Canceled => {
+                OrderStatus::Cancelled
+            }
             polymarket_client_sdk_v2::clob::types::OrderStatusType::Delayed => OrderStatus::Open,
             polymarket_client_sdk_v2::clob::types::OrderStatusType::Unmatched => {
                 OrderStatus::Cancelled

--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -1,15 +1,14 @@
 use alloy::primitives::{Address, ChainId, Signature as AlloySig, B256};
 use k256::ecdsa::SigningKey;
 use metrics::{counter, histogram};
-use polymarket_client_sdk::auth::builder::{Builder as SdkBuilder, Config as BuilderConfig};
-use polymarket_client_sdk::auth::state::Authenticated;
-use polymarket_client_sdk::auth::{Credentials as SdkCredentials, LocalSigner, Normal, Signer};
-use polymarket_client_sdk::clob::types::request::{BalanceAllowanceRequest, OrdersRequest};
-use polymarket_client_sdk::clob::types::{AssetType, OrderType, Side, SignedOrder};
-use polymarket_client_sdk::clob::{Client as SdkClient, Config as SdkConfig};
-use polymarket_client_sdk::contract_config;
-use polymarket_client_sdk::types::{Decimal, U256};
-use polymarket_client_sdk::POLYGON;
+use polymarket_client_sdk_v2::auth::state::Authenticated;
+use polymarket_client_sdk_v2::auth::{LocalSigner, Normal, Signer};
+use polymarket_client_sdk_v2::clob::types::request::{BalanceAllowanceRequest, OrdersRequest};
+use polymarket_client_sdk_v2::clob::types::{AssetType, OrderType, Side, SignedOrder};
+use polymarket_client_sdk_v2::clob::{Client as SdkClient, Config as SdkConfig};
+use polymarket_client_sdk_v2::contract_config;
+use polymarket_client_sdk_v2::types::{Decimal, U256};
+use polymarket_client_sdk_v2::POLYGON;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -66,24 +65,20 @@ impl Signer for AddressOnlySigner {
     }
 }
 
-/// Holds the SDK client in either Normal or Builder auth mode.
-/// Builder mode adds `POLY_BUILDER_*` headers to every authenticated request
-/// for affiliate attribution. All trading methods are available on both via
-/// `impl<K: Kind> Client<Authenticated<K>>`.
-pub(crate) enum AuthenticatedSdkClient {
-    Normal(SdkClient<Authenticated<Normal>>),
-    Builder(SdkClient<Authenticated<SdkBuilder>>),
-}
+/// Wraps the authenticated SDK client. In V1 this enum had a `Builder` variant
+/// that promoted the client to attach `POLY_BUILDER_*` HMAC headers for builder
+/// attribution. In V2 (CLOB V2 cutover 2026-04-28) the SDK builder-promotion
+/// flow is removed — builder attribution is now per-order via the `builder` field
+/// (bytes32 builder code) on the signed order itself, configurable via
+/// `SdkConfig::builder().builder_code(...)`. The wrapper is preserved as a
+/// transparent struct so the `sdk_dispatch!` macro and existing call sites can
+/// stay unchanged.
+pub(crate) struct AuthenticatedSdkClient(SdkClient<Authenticated<Normal>>);
 
-/// Dispatches a method call chain to the inner SDK client regardless of auth kind.
-/// Both `Normal` and `Builder` expose identical trading methods via the generic
-/// `impl<K: Kind> Client<Authenticated<K>>` so each arm compiles identically.
+/// Dispatches a method call chain to the inner SDK client.
 macro_rules! sdk_dispatch {
     ($client:expr, $($rest:tt)*) => {
-        match $client {
-            AuthenticatedSdkClient::Normal(c) => c.$($rest)*,
-            AuthenticatedSdkClient::Builder(c) => c.$($rest)*,
-        }
+        $client.0.$($rest)*
     };
 }
 
@@ -307,7 +302,7 @@ impl Polymarket {
 
     /// Core initialization: derive CLOB credentials + authenticate the SDK client.
     async fn init_sdk_state_inner(&self) -> Result<SdkState, PolymarketError> {
-        use polymarket_client_sdk::auth::{Credentials, ExposeSecret};
+        use polymarket_client_sdk_v2::auth::{Credentials, ExposeSecret};
 
         let signer = self
             .signer
@@ -363,10 +358,8 @@ impl Polymarket {
             .await
             .map_err(PolymarketError::from)?;
 
-        let sdk_client = self.maybe_promote_to_builder(sdk_client).await?;
-
         Ok(SdkState {
-            client: Arc::new(RwLock::new(sdk_client)),
+            client: Arc::new(RwLock::new(AuthenticatedSdkClient(sdk_client))),
             creds,
         })
     }
@@ -391,7 +384,7 @@ impl Polymarket {
         &mut self,
         wallet_address: &str,
     ) -> Result<(), PolymarketError> {
-        use polymarket_client_sdk::auth::Credentials;
+        use polymarket_client_sdk_v2::auth::Credentials;
         use uuid::Uuid;
 
         if self.sdk_state.initialized() {
@@ -441,11 +434,8 @@ impl Polymarket {
             .await
             .map_err(PolymarketError::from)?;
 
-        // Promote to Builder if builder credentials are configured (affiliate attribution)
-        let sdk_client = self.maybe_promote_to_builder(sdk_client).await?;
-
         let state = SdkState {
-            client: Arc::new(RwLock::new(sdk_client)),
+            client: Arc::new(RwLock::new(AuthenticatedSdkClient(sdk_client))),
             creds: creds.clone(),
         };
         let _ = self.sdk_state.set(state);
@@ -456,48 +446,6 @@ impl Polymarket {
         }
 
         Ok(())
-    }
-
-    /// Promote a Normal SDK client to Builder if builder credentials are configured.
-    /// Builder mode attaches `POLY_BUILDER_*` headers to every authenticated CLOB request,
-    /// enabling affiliate revenue attribution.
-    async fn maybe_promote_to_builder(
-        &self,
-        client: SdkClient<Authenticated<Normal>>,
-    ) -> Result<AuthenticatedSdkClient, PolymarketError> {
-        if self.config.has_builder_credentials() {
-            let key: uuid::Uuid = self
-                .config
-                .builder_api_key
-                .as_ref()
-                .ok_or_else(|| PolymarketError::Config("missing builder_api_key".into()))?
-                .parse()
-                .map_err(|e| {
-                    PolymarketError::Config(format!("invalid builder API key UUID: {e}"))
-                })?;
-            let creds = SdkCredentials::new(
-                key,
-                self.config
-                    .builder_secret
-                    .as_ref()
-                    .ok_or_else(|| PolymarketError::Config("missing builder_secret".into()))?
-                    .clone(),
-                self.config
-                    .builder_passphrase
-                    .as_ref()
-                    .ok_or_else(|| PolymarketError::Config("missing builder_passphrase".into()))?
-                    .clone(),
-            );
-            let config = BuilderConfig::local(creds);
-            let builder_client = client
-                .promote_to_builder(config)
-                .await
-                .map_err(PolymarketError::from)?;
-            info!("Polymarket SDK client promoted to Builder (affiliate attribution enabled)");
-            Ok(AuthenticatedSdkClient::Builder(builder_client))
-        } else {
-            Ok(AuthenticatedSdkClient::Normal(client))
-        }
     }
 
     fn get_signer(&self) -> Result<&PrivateKeySigner, OpenPxError> {
@@ -611,7 +559,7 @@ impl Polymarket {
 
     fn parse_sdk_order(
         &self,
-        resp: &polymarket_client_sdk::clob::types::response::OpenOrderResponse,
+        resp: &polymarket_client_sdk_v2::clob::types::response::OpenOrderResponse,
     ) -> Order {
         let side = match resp.side {
             Side::Buy => OrderSide::Buy,
@@ -621,14 +569,14 @@ impl Polymarket {
         };
 
         let status = match &resp.status {
-            polymarket_client_sdk::clob::types::OrderStatusType::Live => OrderStatus::Open,
-            polymarket_client_sdk::clob::types::OrderStatusType::Matched => OrderStatus::Filled,
-            polymarket_client_sdk::clob::types::OrderStatusType::Canceled => OrderStatus::Cancelled,
-            polymarket_client_sdk::clob::types::OrderStatusType::Delayed => OrderStatus::Open,
-            polymarket_client_sdk::clob::types::OrderStatusType::Unmatched => {
+            polymarket_client_sdk_v2::clob::types::OrderStatusType::Live => OrderStatus::Open,
+            polymarket_client_sdk_v2::clob::types::OrderStatusType::Matched => OrderStatus::Filled,
+            polymarket_client_sdk_v2::clob::types::OrderStatusType::Canceled => OrderStatus::Cancelled,
+            polymarket_client_sdk_v2::clob::types::OrderStatusType::Delayed => OrderStatus::Open,
+            polymarket_client_sdk_v2::clob::types::OrderStatusType::Unmatched => {
                 OrderStatus::Cancelled
             }
-            polymarket_client_sdk::clob::types::OrderStatusType::Unknown(_) => OrderStatus::Open,
+            polymarket_client_sdk_v2::clob::types::OrderStatusType::Unknown(_) => OrderStatus::Open,
             _ => OrderStatus::Open, // Handle non-exhaustive enum
         };
 
@@ -2452,7 +2400,7 @@ impl Exchange for Polymarket {
             let ext_signer = self.external_signer.as_ref().ok_or_else(|| {
                 OpenPxError::Config("external signer required but not configured".into())
             })?;
-            let order = &signable_order.order;
+            let order = signable_order.order();
 
             // Determine neg_risk for correct exchange contract
             let neg_risk_result = sdk_dispatch!(
@@ -2471,7 +2419,12 @@ impl Exchange for Polymarket {
                 })?
                 .exchange;
 
-            // Build EIP-712 typed data for Polymarket Order
+            // Build EIP-712 typed data for Polymarket Order — V2 schema.
+            // Domain version bumped to "2" (CTF Exchange V2 cutover 2026-04-28).
+            // V1 fields removed: taker, expiration, nonce, feeRateBps.
+            // V2 fields added: timestamp (ms), metadata (bytes32), builder (bytes32).
+            // Expiration moved out of the signed struct; it travels on the wire body
+            // (signable_order.payload), not the EIP-712 message.
             let typed_data = serde_json::json!({
                 "types": {
                     "EIP712Domain": [
@@ -2484,21 +2437,20 @@ impl Exchange for Polymarket {
                         {"name": "salt", "type": "uint256"},
                         {"name": "maker", "type": "address"},
                         {"name": "signer", "type": "address"},
-                        {"name": "taker", "type": "address"},
                         {"name": "tokenId", "type": "uint256"},
                         {"name": "makerAmount", "type": "uint256"},
                         {"name": "takerAmount", "type": "uint256"},
-                        {"name": "expiration", "type": "uint256"},
-                        {"name": "nonce", "type": "uint256"},
-                        {"name": "feeRateBps", "type": "uint256"},
                         {"name": "side", "type": "uint8"},
-                        {"name": "signatureType", "type": "uint8"}
+                        {"name": "signatureType", "type": "uint8"},
+                        {"name": "timestamp", "type": "uint256"},
+                        {"name": "metadata", "type": "bytes32"},
+                        {"name": "builder", "type": "bytes32"}
                     ]
                 },
                 "primary_type": "Order",
                 "domain": {
                     "name": "Polymarket CTF Exchange",
-                    "version": "1",
+                    "version": "2",
                     "chainId": POLYGON.to_string(),
                     "verifyingContract": format!("{:?}", exchange_contract)
                 },
@@ -2506,15 +2458,14 @@ impl Exchange for Polymarket {
                     "salt": order.salt.to_string(),
                     "maker": format!("{:?}", order.maker),
                     "signer": format!("{:?}", order.signer),
-                    "taker": format!("{:?}", order.taker),
                     "tokenId": order.tokenId.to_string(),
                     "makerAmount": order.makerAmount.to_string(),
                     "takerAmount": order.takerAmount.to_string(),
-                    "expiration": order.expiration.to_string(),
-                    "nonce": order.nonce.to_string(),
-                    "feeRateBps": order.feeRateBps.to_string(),
                     "side": order.side,
-                    "signatureType": order.signatureType
+                    "signatureType": order.signatureType,
+                    "timestamp": order.timestamp.to_string(),
+                    "metadata": format!("{:?}", order.metadata),
+                    "builder": format!("{:?}", order.builder)
                 }
             });
 
@@ -2541,7 +2492,7 @@ impl Exchange for Polymarket {
             })?;
 
             SignedOrder::builder()
-                .order(signable_order.order)
+                .payload(signable_order.payload)
                 .signature(signature)
                 .order_type(signable_order.order_type)
                 .owner(owner)
@@ -3067,7 +3018,7 @@ impl Exchange for Polymarket {
 #[cfg(test)]
 mod tests {
     use super::polymarket_order_type;
-    use polymarket_client_sdk::clob::types::OrderType;
+    use polymarket_client_sdk_v2::clob::types::OrderType;
     use std::collections::HashMap;
 
     #[test]

--- a/engine/exchanges/polymarket/src/swap.rs
+++ b/engine/exchanges/polymarket/src/swap.rs
@@ -16,8 +16,13 @@ use crate::config::DEFAULT_POLYGON_RPC;
 /// Native USDC on Polygon (what MetaMask shows as "USDC")
 pub const NATIVE_USDC_ADDRESS: &str = "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359";
 
-/// Bridged USDC.e on Polygon (what Polymarket uses)
+/// Bridged USDC.e on Polygon (input to CollateralOnramp.wrap() in V2)
 pub const BRIDGED_USDC_E_ADDRESS: &str = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+
+/// CollateralOnramp — wraps USDC.e into pUSD (V2 trading collateral).
+/// API-only flow: approve USDC.e to this address, then call wrap(amount).
+/// Source: https://docs.polymarket.com/resources/contracts
+pub const COLLATERAL_ONRAMP: &str = "0x93070a847efEf7F70739046A929D47a521F5B8ee";
 
 /// Uniswap V3 SwapRouter on Polygon
 const UNISWAP_V3_ROUTER: &str = "0xE592427A0AEce92De3Edee1F18E0157C05861564";

--- a/maintenance/snapshots/polymarket-contracts.snapshot.json
+++ b/maintenance/snapshots/polymarket-contracts.snapshot.json
@@ -1,8 +1,8 @@
 {
-  "_comment": "Vendored Polymarket contract addresses. Asserts engine/exchanges/polymarket/src/{swap,approvals}.rs match. NEVER bypass the contracts_test that reads this file. A wrong address can move user funds to a contract under someone else's control. When Polymarket redeploys (e.g. CLOB V2 cutover 2026-04-28), update this file in lockstep with the source-code constants and verify each new address on https://polygonscan.com/.",
+  "_comment": "Vendored Polymarket contract addresses — refreshed for the CLOB V2 + pUSD cutover (2026-04-28 ~11:00 UTC). Source of truth: https://docs.polymarket.com/resources/contracts. Asserts engine/exchanges/polymarket/src/{swap,approvals}.rs match. NEVER bypass the contracts_test that reads this file. A wrong address can move user funds to a contract under someone else's control. CTF Exchange V2 audits: Quantstamp + Cantina (March 2026).",
   "_chain_id": 137,
   "_chain_name": "polygon",
-  "_last_verified": "2026-04-25",
+  "_last_verified": "2026-04-27",
   "_source_files": [
     "engine/exchanges/polymarket/src/swap.rs",
     "engine/exchanges/polymarket/src/approvals.rs"
@@ -11,37 +11,47 @@
     "NATIVE_USDC_ADDRESS": {
       "address": "0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359",
       "file": "engine/exchanges/polymarket/src/swap.rs",
-      "purpose": "Native USDC on Polygon (Circle's CCTP-bridged version) — the form users typically receive from on-ramps."
+      "purpose": "Native USDC on Polygon (Circle's CCTP-bridged version) — what users typically receive from on-ramps. First leg of the swap: native USDC → USDC.e via Uniswap V3."
     },
     "BRIDGED_USDC_E_ADDRESS": {
       "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
       "file": "engine/exchanges/polymarket/src/swap.rs",
-      "purpose": "USDC.e (PoS-bridged USDC) — Polymarket's collateral token pre-CLOB-V2."
+      "purpose": "USDC.e (PoS-bridged USDC) — second-leg input to CollateralOnramp.wrap() to mint pUSD. Not the trading collateral after V2."
     },
-    "USDC_ADDRESS": {
-      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+    "PUSD_ADDRESS": {
+      "address": "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
       "file": "engine/exchanges/polymarket/src/approvals.rs",
-      "purpose": "USDC.e (same address as BRIDGED_USDC_E_ADDRESS) — used as the collateral approval target."
+      "purpose": "pUSD CollateralToken (proxy) — V2 trading collateral, ERC-20 backed by USDC, backing enforced onchain. Approval target for V2 exchange contracts."
+    },
+    "PUSD_IMPL_ADDRESS": {
+      "address": "0x6bBCef9f7ef3B6C592c99e0f206a0DE94Ad0925f",
+      "file": "engine/exchanges/polymarket/src/approvals.rs",
+      "purpose": "pUSD CollateralToken (implementation) — informational. Approvals always target the proxy, not the impl."
+    },
+    "COLLATERAL_ONRAMP": {
+      "address": "0x93070a847efEf7F70739046A929D47a521F5B8ee",
+      "file": "engine/exchanges/polymarket/src/swap.rs",
+      "purpose": "Permissionless CollateralOnramp — wraps USDC.e into pUSD via wrap(amount). API-only flow target after V2."
     },
     "CTF_ADDRESS": {
       "address": "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
       "file": "engine/exchanges/polymarket/src/approvals.rs",
-      "purpose": "Conditional Tokens Framework (Gnosis CTF, ERC-1155) — the share-token contract."
+      "purpose": "Conditional Tokens Framework (Gnosis CTF, ERC-1155) — share-token contract. Unchanged in V2."
     },
     "CTF_EXCHANGE": {
-      "address": "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E",
+      "address": "0xE111180000d2663C0091e4f400237545B87B996B",
       "file": "engine/exchanges/polymarket/src/approvals.rs",
-      "purpose": "Polymarket CLOB Exchange contract for binary markets (pre-CLOB-V2)."
+      "purpose": "CTF Exchange V2 — V2 binary CLOB exchange. verifyingContract for V2 EIP-712 order domain (version '2'). Audited March 2026 by Quantstamp + Cantina."
     },
     "NEG_RISK_CTF_EXCHANGE": {
-      "address": "0xC5d563A36AE78145C45a50134d48A1215220f80a",
+      "address": "0xe2222d279d744050d28e00520010520000310F59",
       "file": "engine/exchanges/polymarket/src/approvals.rs",
-      "purpose": "Polymarket Neg-Risk CLOB Exchange for multi-outcome markets (pre-CLOB-V2)."
+      "purpose": "Neg Risk CTF Exchange V2 — multi-outcome CLOB exchange. verifyingContract for V2 EIP-712 on neg-risk markets."
     },
     "NEG_RISK_ADAPTER": {
       "address": "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296",
       "file": "engine/exchanges/polymarket/src/approvals.rs",
-      "purpose": "Neg-Risk Adapter — manages multi-outcome share splits/merges/redemptions."
+      "purpose": "Neg-Risk Adapter — multi-outcome share splits/merges/redemptions. Unchanged in V2."
     }
   }
 }


### PR DESCRIPTION
## Summary

Time-critical: lands the V2 contract addresses and the SDK swap from \`polymarket-client-sdk = "0.4.1"\` to \`polymarket_client_sdk_v2 = "=0.5.1"\` ahead of the **2026-04-28 ~11:00 UTC** CLOB V2 cutover. After cutover there is no V1 backward compatibility — this branch needs to land before the maintenance window starts.

Source of truth: <https://docs.polymarket.com/migrating-to-clob-v2> + <https://docs.polymarket.com/resources/contracts>.

## Commits

1. \`6555920\` — **chore(polymarket): rotate contract addresses for CLOB V2 + pUSD cutover**
   - V1 → V2 binary CTF Exchange: \`0x4bFb...\` → \`0xE111180000d2663C0091e4f400237545B87B996B\`
   - V1 → V2 neg-risk CTF Exchange: \`0xC5d5...\` → \`0xe2222d279d744050d28e00520010520000310F59\`
   - \`USDC_ADDRESS\` (USDC.e) → renamed \`PUSD_ADDRESS\` (\`0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB\`)
   - New \`PUSD_IMPL_ADDRESS\`, \`COLLATERAL_ONRAMP\` constants
   - \`maintenance/snapshots/polymarket-contracts.snapshot.json\` mirrors source files exactly; \`contracts_test\` enforces.
   - CTF Exchange V2 audited March 2026 by Quantstamp + Cantina.

2. \`62eb830\` — **chore(polymarket): swap to clob-v2 SDK and rebuild order struct for V2**
   - Cargo dep: \`polymarket-client-sdk 0.4.1\` → \`polymarket_client_sdk_v2 = "=0.5.1"\`
   - V1 \`auth::builder::*\` module is removed in V2; \`AuthenticatedSdkClient\` collapses to a single transparent struct around \`SdkClient<Authenticated<Normal>>\`. \`maybe_promote_to_builder\` deleted.
   - V2 EIP-712 typed_data: domain \`version: "2"\`; \`Order\` struct drops \`taker\`, \`expiration\`, \`nonce\`, \`feeRateBps\`; adds \`timestamp\` (uint256), \`metadata\` (bytes32), \`builder\` (bytes32). External-signer (Privy) flow rewritten to match.
   - \`SignedOrder::builder().payload(signable_order.payload)\` replaces V1 \`.order(...)\` (V2 wraps the order in \`OrderPayload\`).
   - Relayer \`POLY_BUILDER_*\` HMAC headers preserved per migration guide ("your builder API key isn't retired" — relayer keeps the same credentials; only order signing moves to the \`builderCode\` field).

## Test plan
- [x] \`cargo test -p px-exchange-polymarket\` — 20 unit + integration tests + \`contracts_test\` all pass
- [x] \`cargo clippy -p px-exchange-polymarket --all-targets -- -D warnings\` clean
- [x] \`cargo check --workspace\` clean (downstream SDKs + CLI still compile)
- [ ] Pre-cutover: live test against \`https://clob-v2.polymarket.com\` with a tiny test order (cancel before fill) — gated on testnet creds; reviewer to run if available.
- [ ] Post-cutover: V1 \`fee_rate_bps\` / \`nonce\` / \`taker\` references must not creep back in. Mechanically guarded by \`contracts_test\` for addresses; signer changes guarded by manual review.

## Stack
- **This PR is the base of the V2 migration stack.** Batch 0c (pUSD wrap encoders) is stacked on top — see follow-up PR.
- Funds-moving files touched (CODEOWNERS forces human review): \`engine/exchanges/polymarket/src/{clob.rs, signer.rs, approvals.rs, swap.rs, ctf.rs, exchange.rs}\`, \`maintenance/snapshots/polymarket-contracts.snapshot.json\`.
- The legacy \`builder_api_key\` / \`builder_secret\` / \`builder_passphrase\` config fields are intentionally preserved — they're still used by \`relayer.rs\` for gasless tx HMAC auth per the migration guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)