### PR TITLE
chore(polymarket): pUSD wrap calldata encoders for V2 onboarding

### DIFF
--- a/engine/exchanges/polymarket/src/swap.rs
+++ b/engine/exchanges/polymarket/src/swap.rs
@@ -1,8 +1,23 @@
-//! Auto-swap native USDC → USDC.e during Polymarket onboarding.
+//! Auto-swap + wrap during Polymarket V2 onboarding.
 //!
-//! Users fund Polygon wallets with native USDC (0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359)
-//! but Polymarket and fee escrow use bridged USDC.e (0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174).
-//! This module detects native USDC and swaps it to USDC.e via Uniswap V3 before approvals.
+//! After the 2026-04-28 CLOB V2 cutover, Polymarket trades against **pUSD**
+//! (`0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB`) — not USDC.e. Users hold one
+//! of three forms of dollars on Polygon:
+//!   1. Native USDC (`0x3c499c5...`) — what most Polygon on-ramps deliver.
+//!   2. Bridged USDC.e (`0x2791Bca...`) — pre-V2 collateral, still accepted by
+//!      `CollateralOnramp.wrap()` as input.
+//!   3. pUSD (`0xC011a7E...`) — the V2 trading collateral.
+//!
+//! This module encodes the calldata for the full onboarding pipeline so a relayer
+//! or wallet can execute the chain end-to-end:
+//!
+//! ```text
+//! native USDC ── (Uniswap V3 0.01% pool) ──► USDC.e ── (CollateralOnramp.wrap) ──► pUSD
+//! ```
+//!
+//! Each leg is exposed as a separate encoder. Callers are expected to send the
+//! transactions in order with appropriate approvals between them. The encoders
+//! never touch private keys; signing happens in the relayer or wallet layer.
 
 use alloy::primitives::{Address, Uint, U256};
 use alloy::providers::{Provider, ProviderBuilder};
@@ -11,6 +26,7 @@ use alloy::sol_types::SolCall;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+use crate::approvals::PUSD_ADDRESS;
 use crate::config::DEFAULT_POLYGON_RPC;
 
 /// Native USDC on Polygon (what MetaMask shows as "USDC")
@@ -67,6 +83,18 @@ sol! {
         }
 
         function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+    }
+
+    /// Permissionless onramp that wraps USDC.e into pUSD 1:1. Required after the
+    /// 2026-04-28 CLOB V2 cutover, since trading collateral is now pUSD rather
+    /// than USDC.e. Source: https://docs.polymarket.com/concepts/pusd
+    ///
+    /// `wrap(_asset, _to, _amount)` — `_asset` MUST be USDC.e
+    /// (`0x2791Bca...`); pUSD is minted to `_to` (recipient may differ from
+    /// msg.sender). Caller must approve USDC.e to this contract first.
+    /// Reverts with `OnlyUnpaused()` if the asset is admin-paused.
+    interface ICollateralOnramp {
+        function wrap(address _asset, address _to, uint256 _amount) external;
     }
 }
 
@@ -205,6 +233,52 @@ pub fn encode_swap_calldata_u128(
     encode_swap_calldata(U256::from(amount_in), recipient, U256::from(min_out))
 }
 
+/// Encode `approve(CollateralOnramp, amount)` on USDC.e. Required before
+/// `CollateralOnramp.wrap()` can transfer USDC.e from the caller.
+/// Returns `(to, calldata)` targeting the USDC.e contract.
+pub fn encode_usdc_e_approval_to_onramp(amount: U256) -> (String, String) {
+    let onramp = Address::from_str(COLLATERAL_ONRAMP).expect("valid CollateralOnramp address");
+    let call = ISwapERC20::approveCall {
+        spender: onramp,
+        amount,
+    };
+    let calldata = alloy::primitives::hex::encode(call.abi_encode());
+    (BRIDGED_USDC_E_ADDRESS.to_string(), format!("0x{calldata}"))
+}
+
+/// Encode `CollateralOnramp.wrap(USDC.e, recipient, amount)`. Wraps the caller's
+/// USDC.e 1:1 into pUSD, minted to `recipient`. Caller must have approved
+/// USDC.e to the Onramp first (see `encode_usdc_e_approval_to_onramp`).
+/// Returns `(to, calldata)` targeting the CollateralOnramp contract.
+pub fn encode_pusd_wrap_calldata(recipient: &str, amount: U256) -> (String, String) {
+    let asset_addr =
+        Address::from_str(BRIDGED_USDC_E_ADDRESS).expect("valid USDC.e address");
+    let to_addr = Address::from_str(recipient).expect("valid recipient address");
+    let call = ICollateralOnramp::wrapCall {
+        _asset: asset_addr,
+        _to: to_addr,
+        _amount: amount,
+    };
+    let calldata = alloy::primitives::hex::encode(call.abi_encode());
+    (COLLATERAL_ONRAMP.to_string(), format!("0x{calldata}"))
+}
+
+/// Convenience wrapper: encode the USDC.e → Onramp approval from a u128 amount.
+pub fn encode_usdc_e_approval_to_onramp_u128(amount: u128) -> (String, String) {
+    encode_usdc_e_approval_to_onramp(U256::from(amount))
+}
+
+/// Convenience wrapper: encode the wrap call from a u128 amount.
+pub fn encode_pusd_wrap_calldata_u128(recipient: &str, amount: u128) -> (String, String) {
+    encode_pusd_wrap_calldata(recipient, U256::from(amount))
+}
+
+/// Check the caller's pUSD balance. Returns 0 on any error (fail-silent),
+/// matching the convention used by `check_native_usdc_balance` and friends.
+pub async fn check_pusd_balance(rpc_url: Option<&str>, owner: &str) -> u128 {
+    check_erc20_balance(rpc_url, PUSD_ADDRESS, owner).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -236,5 +310,72 @@ mod tests {
         assert!(r.approval_tx.is_none());
         assert!(r.swap_tx.is_none());
         assert!(r.error.is_none());
+    }
+
+    #[test]
+    fn test_encode_usdc_e_approval_to_onramp() {
+        let (to, data) = encode_usdc_e_approval_to_onramp(U256::from(1_000_000u64));
+        assert_eq!(to, BRIDGED_USDC_E_ADDRESS);
+        // approve(address,uint256) selector = 0x095ea7b3
+        assert!(data.starts_with("0x095ea7b3"));
+        // The lowercase Onramp address must appear in the encoded calldata
+        // (32-byte left-padded). This guards against accidentally approving the
+        // wrong contract — wrong spender = funds at risk.
+        let onramp_no_0x = COLLATERAL_ONRAMP.trim_start_matches("0x").to_lowercase();
+        assert!(
+            data.to_lowercase().contains(&onramp_no_0x),
+            "approval calldata must reference CollateralOnramp address {COLLATERAL_ONRAMP}"
+        );
+    }
+
+    #[test]
+    fn test_encode_pusd_wrap_calldata() {
+        let recipient = "0x1234567890123456789012345678901234567890";
+        let (to, data) = encode_pusd_wrap_calldata(recipient, U256::from(2_500_000u64));
+        assert_eq!(to, COLLATERAL_ONRAMP);
+        // Calldata must contain the USDC.e asset address (it's the only valid
+        // input asset for wrap; passing anything else reverts on-chain).
+        let usdc_e_no_0x = BRIDGED_USDC_E_ADDRESS.trim_start_matches("0x").to_lowercase();
+        assert!(
+            data.to_lowercase().contains(&usdc_e_no_0x),
+            "wrap calldata must reference USDC.e {BRIDGED_USDC_E_ADDRESS}"
+        );
+        // Recipient address must appear in calldata — wrong recipient = funds at risk.
+        let recipient_no_0x = recipient.trim_start_matches("0x").to_lowercase();
+        assert!(
+            data.to_lowercase().contains(&recipient_no_0x),
+            "wrap calldata must reference recipient {recipient}"
+        );
+        // Amount appears as the third arg (last 32 bytes of calldata).
+        assert!(data.ends_with(&format!("{:064x}", 2_500_000u64)));
+    }
+
+    #[test]
+    fn test_pusd_wrap_calldata_distinct_from_swap_and_approve() {
+        // Selector regression: wrap, exactInputSingle, and approve must all
+        // have distinct 4-byte function selectors.
+        let recipient = "0x0000000000000000000000000000000000000001";
+        let (_, wrap_data) = encode_pusd_wrap_calldata(recipient, U256::from(1_000_000u64));
+        let (_, swap_data) =
+            encode_swap_calldata(U256::from(1_000_000u64), recipient, U256::from(995_000u64));
+        let (_, approve_data) = encode_usdc_e_approval_to_onramp(U256::from(1_000_000u64));
+        assert_ne!(&wrap_data[..10], &swap_data[..10]);
+        assert_ne!(&wrap_data[..10], &approve_data[..10]);
+        assert_ne!(&swap_data[..10], &approve_data[..10]);
+    }
+
+    #[test]
+    fn test_u128_wrappers_round_trip() {
+        // Verify u128 wrappers produce identical output to their U256 counterparts.
+        let amount = 10_000_000u128;
+        let recipient = "0xabcdef0123456789abcdef0123456789abcdef01";
+
+        let (to_a, data_a) = encode_usdc_e_approval_to_onramp(U256::from(amount));
+        let (to_b, data_b) = encode_usdc_e_approval_to_onramp_u128(amount);
+        assert_eq!((to_a, data_a), (to_b, data_b));
+
+        let (to_c, data_c) = encode_pusd_wrap_calldata(recipient, U256::from(amount));
+        let (to_d, data_d) = encode_pusd_wrap_calldata_u128(recipient, amount);
+        assert_eq!((to_c, data_c), (to_d, data_d));
     }
 }


### PR DESCRIPTION
## Summary

Stacked on **#54** (chore/polymarket-v2-migration). Adds the second leg of the V2 onboarding pipeline: USDC.e → pUSD via the permissionless \`CollateralOnramp\`. After the 2026-04-28 cutover, Polymarket trades against pUSD; the existing native-USDC → USDC.e Uniswap leg alone is no longer sufficient.

The full pipeline now encoded in \`engine/exchanges/polymarket/src/swap.rs\`:

\`\`\`text
native USDC ── (Uniswap V3 0.01% pool) ──► USDC.e ── (CollateralOnramp.wrap) ──► pUSD
\`\`\`

## What's added (no signing — calldata encoders only)

- \`encode_usdc_e_approval_to_onramp(amount)\` — approves USDC.e to \`CollateralOnramp\` (\`0x93070a847efEf7F70739046A929D47a521F5B8ee\`)
- \`encode_pusd_wrap_calldata(recipient, amount)\` — encodes \`wrap(USDC.e, recipient, amount)\` on the Onramp. Recipient may differ from \`msg.sender\` per V2 spec; USDC.e asset is hardcoded since the Onramp only accepts USDC.e as input
- \`encode_usdc_e_approval_to_onramp_u128\`, \`encode_pusd_wrap_calldata_u128\` — u128 convenience wrappers
- \`check_pusd_balance(rpc_url, owner)\` — pUSD balance read, fail-silent on RPC errors

## Funds-safety note

Verified the V2 wrap signature directly against <https://docs.polymarket.com/concepts/pusd>:

\`\`\`solidity
function wrap(address _asset, address _to, uint256 _amount) external
\`\`\`

A first draft of this PR assumed \`wrap(uint256)\` (selector \`0xea598cb0\`) — that would have called the wrong function and reverted on-chain. The 3-arg signature is now reflected in the \`ICollateralOnramp\` \`sol!\` interface, the encoder, and the unit tests. Tests assert the USDC.e asset address + recipient + amount all appear in the calldata so this can't silently regress.

## Test plan

- [x] \`cargo test -p px-exchange-polymarket --lib\` — 52 tests pass (including 4 new pUSD wrap tests + selector regression test)
- [x] \`cargo clippy -p px-exchange-polymarket --all-targets -- -D warnings\` clean
- [ ] CollateralOfframp / \`unwrap()\` flow is intentionally **out of scope** for this PR — separate withdraw concern; flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)