### PR TITLE
feat(core): scaffold 14 unified Exchange-trait methods + SDK regen

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -26,6 +26,7 @@ This page summarizes user-facing releases.
 
 ### Added
 
+- **core**: 14 new unified `Exchange` trait methods scaffolded (default `Err(NotSupported)`); per-venue impls land in follow-up PRs. New surface: `fetch_events`, `fetch_event`, `fetch_series`, `fetch_series_one`, `fetch_market_tags`, `fetch_orderbooks_batch`, `fetch_midpoint`, `fetch_midpoints_batch`, `fetch_spread`, `fetch_last_trade_price`, `fetch_open_interest`, `fetch_user_trades`, `cancel_all_orders`, `create_orders_batch`. New models: `Event`, `Series`, `SettlementSource`, `Tag`, `Spread`, `LastTrade`, `UserTrade`. New request types: `EventsRequest`, `SeriesRequest`, `MidpointRequest`, `UserTradesRequest`, `NewOrder`. ([#56](https://github.com/openpx-trade/openpx/pull/56))
 - **core**: `Exchange::fetch_server_time()` returns each venue's wall-clock as `DateTime<Utc>` for clock-skew correction in signing-sensitive paths. `ExchangeInfo` gains `has_fetch_server_time: bool`. ([#26](https://github.com/openpx-trade/openpx/pull/26))
 
 ### Fixed

--- a/docs/reference/types.mdx
+++ b/docs/reference/types.mdx
@@ -64,23 +64,74 @@ OHLCV candlestick, normalized across all exchanges. Prices are decimals (0.0 to 
 | `volume` | `number` | Trade volume in contracts. 0.0 if exchange doesn't provide volume. |
 
 
+## `Event`
+
+A grouping of related markets. On Kalshi, an Event is a single resolution (e.g. "Will Candidate X win State Y?") with one or more contracts. On Polymarket, an Event is the parent of one or more Markets sharing a common theme (e.g. "2028 US Presidential Election" with markets per candidate).
+
+| Field | Type | Description |
+|---|---|---|
+| `category` | `['string', 'null']` *(optional)* |  |
+| `description` | `['string', 'null']` *(optional)* |  |
+| `end_ts` | `['string', 'null']` *(optional)* |  |
+| `id` | `string` |  |
+| `last_updated_ts` | `['string', 'null']` *(optional)* |  |
+| `market_ids` | `string`[] *(optional)* |  |
+| `mutually_exclusive` | `['boolean', 'null']` *(optional)* |  |
+| `open_interest` | `['number', 'null']` *(optional)* |  |
+| `series_id` | `['string', 'null']` *(optional)* |  |
+| `slug` | `['string', 'null']` *(optional)* |  |
+| `start_ts` | `['string', 'null']` *(optional)* |  |
+| `status` | `['string', 'null']` *(optional)* |  |
+| `title` | `string` |  |
+| `volume` | `['number', 'null']` *(optional)* |  |
+
+
+## `EventsRequest`
+
+Request for fetching events.
+
+| Field | Type | Description |
+|---|---|---|
+| `cursor` | `['string', 'null']` *(optional)* |  |
+| `limit` | `['integer', 'null']` *(optional)* |  |
+| `min_close_ts` | `['integer', 'null']` *(optional)* | Unix seconds — only events closing at or after this timestamp. |
+| `min_updated_ts` | `['integer', 'null']` *(optional)* | Unix seconds — only events updated at or after this timestamp. |
+| `series_id` | `['string', 'null']` *(optional)* | Filter by series ID / ticker. |
+| `status` | `['string', 'null']` *(optional)* | Filter by lifecycle status — venue-specific values (e.g. `open`, `closed`, `settled` on Kalshi; `closed=true/false` on Polymarket). |
+| `with_nested_markets` | `['boolean', 'null']` *(optional)* | Include the events' nested `Market` objects when supported. |
+
+
 ## `ExchangeInfo`
 
 | Field | Type | Description |
 |---|---|---|
 | `has_approvals` | `boolean` |  |
+| `has_cancel_all_orders` | `boolean` |  |
 | `has_cancel_order` | `boolean` |  |
 | `has_create_order` | `boolean` |  |
+| `has_create_orders_batch` | `boolean` |  |
 | `has_fetch_balance` | `boolean` |  |
+| `has_fetch_event` | `boolean` |  |
+| `has_fetch_events` | `boolean` |  |
 | `has_fetch_fills` | `boolean` |  |
+| `has_fetch_last_trade_price` | `boolean` |  |
+| `has_fetch_market_tags` | `boolean` |  |
 | `has_fetch_markets` | `boolean` |  |
+| `has_fetch_midpoint` | `boolean` |  |
+| `has_fetch_midpoints_batch` | `boolean` |  |
+| `has_fetch_open_interest` | `boolean` |  |
 | `has_fetch_orderbook` | `boolean` |  |
 | `has_fetch_orderbook_history` | `boolean` |  |
+| `has_fetch_orderbooks_batch` | `boolean` |  |
 | `has_fetch_positions` | `boolean` |  |
 | `has_fetch_price_history` | `boolean` |  |
+| `has_fetch_series` | `boolean` |  |
+| `has_fetch_series_one` | `boolean` |  |
 | `has_fetch_server_time` | `boolean` |  |
+| `has_fetch_spread` | `boolean` |  |
 | `has_fetch_trades` | `boolean` |  |
 | `has_fetch_user_activity` | `boolean` |  |
+| `has_fetch_user_trades` | `boolean` |  |
 | `has_refresh_balance` | `boolean` |  |
 | `has_websocket` | `boolean` |  |
 | `id` | `string` |  |
@@ -141,6 +192,18 @@ Why a specific book was invalidated — handed to users so they can decide wheth
 - `'Lag'`
 - `'ExchangeReset'`
 - `SequenceGap`
+
+
+## `LastTrade`
+
+Last public trade price + side + size for a market outcome. Distinct from the full `MarketTrade` tape: this is just "what just printed?" — common UI need that doesn't require the full trade history.
+
+| Field | Type | Description |
+|---|---|---|
+| `price` | `number` |  |
+| `side` | [`OrderSide`](#orderside) |  |
+| `size` | `number` |  |
+| `ts_ms` | `integer` |  |
 
 
 ## `LiquidityRole`
@@ -278,6 +341,35 @@ Market type classification.
 - `'binary'`
 - `'categorical'`
 - `'scalar'`
+
+
+## `MidpointRequest`
+
+Request for midpoint / spread / last-trade-price methods. The same shape is reused for all three since they target the same outcome and accept the same identifier inputs.
+
+| Field | Type | Description |
+|---|---|---|
+| `market_id` | `string` |  |
+| `outcome` | `['string', 'null']` *(optional)* |  |
+| `token_id` | `['string', 'null']` *(optional)* |  |
+
+
+## `NewOrder`
+
+One order in a `create_orders_batch` call. Each venue caps the batch size (Polymarket: 15; Kalshi: token-budget-dependent).
+
+| Field | Type | Description |
+|---|---|---|
+| `client_order_id` | `['string', 'null']` *(optional)* | Kalshi-specific idempotency key. |
+| `expiration_ts` | `['integer', 'null']` *(optional)* | Unix seconds. Required for `OrderType::Gtc` orders that should expire. |
+| `market_id` | `string` |  |
+| `order_type` | [`OrderType`](#ordertype) |  |
+| `outcome` | `string` |  |
+| `post_only` | `['boolean', 'null']` *(optional)* | Polymarket: pin maker-only. Ignored on Kalshi. |
+| `price` | `number` |  |
+| `reduce_only` | `['boolean', 'null']` *(optional)* | Kalshi: only allow size reductions. Maps to `reduce_only=true`. |
+| `side` | [`OrderSide`](#orderside) |  |
+| `size` | `number` |  |
 
 
 ## `Order`
@@ -453,6 +545,35 @@ Bid or ask side. Serializes as "bid"/"ask" on the wire.
 - `'ask'`
 
 
+## `Series`
+
+A recurring family of events. Examples: a weekly inflation reading, a monthly nonfarm payrolls release, a regular sports season. On Kalshi, a Series is identified by `series_ticker` (e.g. `KXPRES`). On Polymarket, a Series wraps multiple Events with shared metadata.
+
+| Field | Type | Description |
+|---|---|---|
+| `category` | `['string', 'null']` *(optional)* |  |
+| `fee_type` | `['string', 'null']` *(optional)* |  |
+| `frequency` | `['string', 'null']` *(optional)* |  |
+| `id` | `string` |  |
+| `last_updated_ts` | `['string', 'null']` *(optional)* |  |
+| `settlement_sources` | [`SettlementSource`](#settlementsource)[] *(optional)* |  |
+| `tags` | `string`[] *(optional)* |  |
+| `title` | `string` |  |
+| `volume` | `['number', 'null']` *(optional)* |  |
+
+
+## `SeriesRequest`
+
+Request for fetching series.
+
+| Field | Type | Description |
+|---|---|---|
+| `category` | `['string', 'null']` *(optional)* | Filter by category (e.g. `Politics`, `Sports`). |
+| `cursor` | `['string', 'null']` *(optional)* |  |
+| `include_volume` | `['boolean', 'null']` *(optional)* | Include traded volume in the response when the venue supports it. |
+| `limit` | `['integer', 'null']` *(optional)* |  |
+
+
 ## `SessionEvent`
 
 Connection-level events, emitted on a channel separate from `WsUpdate` so a reconnect is observable as a single global signal rather than per-market.
@@ -473,6 +594,37 @@ Connection-level events, emitted on a channel separate from `WsUpdate` so a reco
 - `message`
 
 
+## `SettlementSource`
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `['string', 'null']` *(optional)* |  |
+| `url` | `['string', 'null']` *(optional)* |  |
+
+
+## `Spread`
+
+Top-of-book bid/ask + spread for a market outcome. Lighter than a full `Orderbook` — useful for liquidity scoring and PnL marks where only the best levels are needed.
+
+| Field | Type | Description |
+|---|---|---|
+| `ask` | `number` |  |
+| `bid` | `number` |  |
+| `spread` | `number` |  |
+| `ts_ms` | `['integer', 'null']` *(optional)* |  |
+
+
+## `Tag`
+
+A category or tag attached to a market or event. Used for filtering and search. Kalshi exposes tags via category-keyed lookups; Polymarket exposes per-market and per-event tag arrays.
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` |  |
+| `name` | `string` |  |
+| `slug` | `['string', 'null']` *(optional)* |  |
+
+
 ## `TradesRequest`
 
 Request for fetching recent public trades ("tape") for a market outcome.
@@ -487,6 +639,42 @@ Request for fetching recent public trades ("tape") for a market outcome.
 | `outcome` | `['string', 'null']` *(optional)* |  |
 | `start_ts` | `['integer', 'null']` *(optional)* | Unix seconds (inclusive) |
 | `token_id` | `['string', 'null']` *(optional)* |  |
+
+
+## `UserTrade`
+
+A user-facing trade row: distinct from `Fill` because it carries auxiliary fields some venues expose (realized PnL, on-chain tx hash, owner wallet) but others do not. Polymarket Data `/trades` returns these natively; Kalshi `/portfolio/fills` returns a subset, with `realized_pnl` and `tx_hash` left as `None`.
+
+| Field | Type | Description |
+|---|---|---|
+| `asset_id` | `['string', 'null']` *(optional)* |  |
+| `condition_id` | `['string', 'null']` *(optional)* |  |
+| `fee` | `['number', 'null']` *(optional)* |  |
+| `id` | `string` |  |
+| `market_id` | `string` |  |
+| `owner` | `['string', 'null']` *(optional)* |  |
+| `price` | `number` |  |
+| `realized_pnl` | `['number', 'null']` *(optional)* |  |
+| `role` | [`LiquidityRole`](#liquidityrole) \| `null` *(optional)* |  |
+| `side` | [`OrderSide`](#orderside) |  |
+| `size` | `number` |  |
+| `ts_ms` | `integer` |  |
+| `tx_hash` | `['string', 'null']` *(optional)* |  |
+
+
+## `UserTradesRequest`
+
+Request for `fetch_user_trades`.
+
+| Field | Type | Description |
+|---|---|---|
+| `cursor` | `['string', 'null']` *(optional)* |  |
+| `end_ts` | `['integer', 'null']` *(optional)* | Unix seconds (inclusive) |
+| `limit` | `['integer', 'null']` *(optional)* |  |
+| `market_id` | `['string', 'null']` *(optional)* |  |
+| `side` | [`OrderSide`](#orderside) \| `null` *(optional)* |  |
+| `start_ts` | `['integer', 'null']` *(optional)* | Unix seconds (inclusive) |
+| `user_address` | `['string', 'null']` *(optional)* | `None` = caller's own trades (auth required on both venues). `Some(addr)` = public lookup for `addr` (Polymarket only; Kalshi returns `NotSupported`). |
 
 
 ## `WsUpdate`

--- a/engine/core/src/exchange/traits.rs
+++ b/engine/core/src/exchange/traits.rs
@@ -240,10 +240,7 @@ pub trait Exchange: Send + Sync {
     }
 
     /// Fetch the most recent public trade for a market outcome.
-    async fn fetch_last_trade_price(
-        &self,
-        req: MidpointRequest,
-    ) -> Result<LastTrade, OpenPxError> {
+    async fn fetch_last_trade_price(&self, req: MidpointRequest) -> Result<LastTrade, OpenPxError> {
         let _ = req;
         Err(OpenPxError::Exchange(
             crate::error::ExchangeError::NotSupported("fetch_last_trade_price".into()),
@@ -284,10 +281,7 @@ pub trait Exchange: Send + Sync {
 
     /// Cancel all of the caller's open orders. When `market_id.is_some()`,
     /// cancel only orders on that market.
-    async fn cancel_all_orders(
-        &self,
-        market_id: Option<&str>,
-    ) -> Result<Vec<Order>, OpenPxError> {
+    async fn cancel_all_orders(&self, market_id: Option<&str>) -> Result<Vec<Order>, OpenPxError> {
         let _ = market_id;
         Err(OpenPxError::Exchange(
             crate::error::ExchangeError::NotSupported("cancel_all_orders".into()),
@@ -298,10 +292,7 @@ pub trait Exchange: Send + Sync {
     /// batch size — Polymarket at 15, Kalshi at a token-budget-dependent
     /// number. Implementations should reject batches that exceed their cap
     /// up-front rather than splitting silently.
-    async fn create_orders_batch(
-        &self,
-        orders: Vec<NewOrder>,
-    ) -> Result<Vec<Order>, OpenPxError> {
+    async fn create_orders_batch(&self, orders: Vec<NewOrder>) -> Result<Vec<Order>, OpenPxError> {
         let _ = orders;
         Err(OpenPxError::Exchange(
             crate::error::ExchangeError::NotSupported("create_orders_batch".into()),

--- a/engine/core/src/exchange/traits.rs
+++ b/engine/core/src/exchange/traits.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 
 use crate::error::OpenPxError;
 use crate::models::{
-    Candlestick, Fill, Market, MarketTrade, Order, OrderSide, Orderbook, OrderbookSnapshot,
-    Position, PriceHistoryInterval,
+    Candlestick, Event, Fill, LastTrade, Market, MarketTrade, Order, OrderSide, OrderType,
+    Orderbook, OrderbookSnapshot, Position, PriceHistoryInterval, Series, Spread, Tag, UserTrade,
 };
 
 use super::config::{FetchMarketsParams, FetchOrdersParams, FetchUserActivityParams};
@@ -154,6 +154,160 @@ pub trait Exchange: Send + Sync {
         ))
     }
 
+    /// Fetch a page of events. An event groups one or more markets that share
+    /// a resolution (Kalshi) or theme (Polymarket).
+    /// Returns `(events, next_cursor)`.
+    async fn fetch_events(
+        &self,
+        req: EventsRequest,
+    ) -> Result<(Vec<Event>, Option<String>), OpenPxError> {
+        let _ = req;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_events".into()),
+        ))
+    }
+
+    /// Fetch a single event by ID or slug (whichever the venue accepts).
+    async fn fetch_event(&self, id: &str) -> Result<Event, OpenPxError> {
+        let _ = id;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_event".into()),
+        ))
+    }
+
+    /// Fetch L2 orderbooks for multiple markets in one round-trip. Both
+    /// venues expose a batch book endpoint (Kalshi `/markets/orderbooks`,
+    /// Polymarket `/books`); this method exposes that as a unified primitive.
+    async fn fetch_orderbooks_batch(
+        &self,
+        market_ids: Vec<String>,
+    ) -> Result<Vec<Orderbook>, OpenPxError> {
+        let _ = market_ids;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_orderbooks_batch".into()),
+        ))
+    }
+
+    /// Fetch a page of series. A series is a recurring family of events
+    /// (weekly inflation prints, monthly NFP, sports seasons, etc.).
+    /// Returns `(series, next_cursor)`.
+    async fn fetch_series(
+        &self,
+        req: SeriesRequest,
+    ) -> Result<(Vec<Series>, Option<String>), OpenPxError> {
+        let _ = req;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_series".into()),
+        ))
+    }
+
+    /// Fetch a single series by ID or ticker.
+    async fn fetch_series_one(&self, id: &str) -> Result<Series, OpenPxError> {
+        let _ = id;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_series_one".into()),
+        ))
+    }
+
+    /// Fetch the midpoint price for a single market outcome. Cheaper than
+    /// pulling a full orderbook when only the mark price is needed.
+    async fn fetch_midpoint(&self, req: MidpointRequest) -> Result<f64, OpenPxError> {
+        let _ = req;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_midpoint".into()),
+        ))
+    }
+
+    /// Fetch midpoints for multiple market outcomes in one round-trip.
+    /// Returns a map keyed by the input identifier (token_id on Polymarket,
+    /// ticker on Kalshi).
+    async fn fetch_midpoints_batch(
+        &self,
+        market_ids: Vec<String>,
+    ) -> Result<HashMap<String, f64>, OpenPxError> {
+        let _ = market_ids;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_midpoints_batch".into()),
+        ))
+    }
+
+    /// Fetch the top-of-book spread (best bid, best ask, ask - bid).
+    async fn fetch_spread(&self, req: MidpointRequest) -> Result<Spread, OpenPxError> {
+        let _ = req;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_spread".into()),
+        ))
+    }
+
+    /// Fetch the most recent public trade for a market outcome.
+    async fn fetch_last_trade_price(
+        &self,
+        req: MidpointRequest,
+    ) -> Result<LastTrade, OpenPxError> {
+        let _ = req;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_last_trade_price".into()),
+        ))
+    }
+
+    /// Fetch the open interest (total outstanding contracts) for a market.
+    async fn fetch_open_interest(&self, market_id: &str) -> Result<f64, OpenPxError> {
+        let _ = market_id;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_open_interest".into()),
+        ))
+    }
+
+    /// Fetch a user's trade history. Distinct from `fetch_fills` because some
+    /// venues (Polymarket) carry on-chain fields like `tx_hash` and a
+    /// `realized_pnl` that don't fit the `Fill` model. When
+    /// `req.user_address` is `None`, returns the authenticated caller's own
+    /// trades. When `Some(addr)`, returns a public lookup for that wallet
+    /// (Polymarket only — Kalshi returns `NotSupported` in that case).
+    async fn fetch_user_trades(
+        &self,
+        req: UserTradesRequest,
+    ) -> Result<(Vec<UserTrade>, Option<String>), OpenPxError> {
+        let _ = req;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_user_trades".into()),
+        ))
+    }
+
+    /// Fetch the tag set associated with a market (or its parent event).
+    async fn fetch_market_tags(&self, market_id: &str) -> Result<Vec<Tag>, OpenPxError> {
+        let _ = market_id;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("fetch_market_tags".into()),
+        ))
+    }
+
+    /// Cancel all of the caller's open orders. When `market_id.is_some()`,
+    /// cancel only orders on that market.
+    async fn cancel_all_orders(
+        &self,
+        market_id: Option<&str>,
+    ) -> Result<Vec<Order>, OpenPxError> {
+        let _ = market_id;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("cancel_all_orders".into()),
+        ))
+    }
+
+    /// Submit multiple orders in a single round-trip. Both venues cap the
+    /// batch size — Polymarket at 15, Kalshi at a token-budget-dependent
+    /// number. Implementations should reject batches that exceed their cap
+    /// up-front rather than splitting silently.
+    async fn create_orders_batch(
+        &self,
+        orders: Vec<NewOrder>,
+    ) -> Result<Vec<Order>, OpenPxError> {
+        let _ = orders;
+        Err(OpenPxError::Exchange(
+            crate::error::ExchangeError::NotSupported("create_orders_batch".into()),
+        ))
+    }
+
     fn describe(&self) -> ExchangeInfo {
         ExchangeInfo {
             id: self.id(),
@@ -173,6 +327,20 @@ pub trait Exchange: Send + Sync {
             has_refresh_balance: false,
             has_websocket: false,
             has_fetch_orderbook_history: false,
+            has_fetch_events: false,
+            has_fetch_event: false,
+            has_fetch_orderbooks_batch: false,
+            has_fetch_series: false,
+            has_fetch_series_one: false,
+            has_fetch_midpoint: false,
+            has_fetch_midpoints_batch: false,
+            has_fetch_spread: false,
+            has_fetch_last_trade_price: false,
+            has_fetch_open_interest: false,
+            has_fetch_user_trades: false,
+            has_fetch_market_tags: false,
+            has_cancel_all_orders: false,
+            has_create_orders_batch: false,
         }
     }
 
@@ -200,6 +368,20 @@ pub struct ExchangeInfo {
     pub has_refresh_balance: bool,
     pub has_websocket: bool,
     pub has_fetch_orderbook_history: bool,
+    pub has_fetch_events: bool,
+    pub has_fetch_event: bool,
+    pub has_fetch_orderbooks_batch: bool,
+    pub has_fetch_series: bool,
+    pub has_fetch_series_one: bool,
+    pub has_fetch_midpoint: bool,
+    pub has_fetch_midpoints_batch: bool,
+    pub has_fetch_spread: bool,
+    pub has_fetch_last_trade_price: bool,
+    pub has_fetch_open_interest: bool,
+    pub has_fetch_user_trades: bool,
+    pub has_fetch_market_tags: bool,
+    pub has_cancel_all_orders: bool,
+    pub has_create_orders_batch: bool,
 }
 
 /// Request for fetching an L2 orderbook.
@@ -257,4 +439,85 @@ pub struct OrderbookHistoryRequest {
     pub end_ts: Option<i64>,
     pub limit: Option<usize>,
     pub cursor: Option<String>,
+}
+
+/// Request for fetching events.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct EventsRequest {
+    pub limit: Option<usize>,
+    pub cursor: Option<String>,
+    /// Filter by lifecycle status — venue-specific values (e.g. `open`,
+    /// `closed`, `settled` on Kalshi; `closed=true/false` on Polymarket).
+    pub status: Option<String>,
+    /// Filter by series ID / ticker.
+    pub series_id: Option<String>,
+    /// Include the events' nested `Market` objects when supported.
+    pub with_nested_markets: Option<bool>,
+    /// Unix seconds — only events closing at or after this timestamp.
+    pub min_close_ts: Option<i64>,
+    /// Unix seconds — only events updated at or after this timestamp.
+    pub min_updated_ts: Option<i64>,
+}
+
+/// Request for fetching series.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SeriesRequest {
+    pub limit: Option<usize>,
+    pub cursor: Option<String>,
+    /// Filter by category (e.g. `Politics`, `Sports`).
+    pub category: Option<String>,
+    /// Include traded volume in the response when the venue supports it.
+    pub include_volume: Option<bool>,
+}
+
+/// Request for midpoint / spread / last-trade-price methods. The same shape
+/// is reused for all three since they target the same outcome and accept the
+/// same identifier inputs.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct MidpointRequest {
+    pub market_id: String,
+    pub outcome: Option<String>,
+    pub token_id: Option<String>,
+}
+
+/// Request for `fetch_user_trades`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct UserTradesRequest {
+    /// `None` = caller's own trades (auth required on both venues).
+    /// `Some(addr)` = public lookup for `addr` (Polymarket only; Kalshi
+    /// returns `NotSupported`).
+    pub user_address: Option<String>,
+    pub market_id: Option<String>,
+    pub side: Option<OrderSide>,
+    /// Unix seconds (inclusive)
+    pub start_ts: Option<i64>,
+    /// Unix seconds (inclusive)
+    pub end_ts: Option<i64>,
+    pub limit: Option<usize>,
+    pub cursor: Option<String>,
+}
+
+/// One order in a `create_orders_batch` call. Each venue caps the batch size
+/// (Polymarket: 15; Kalshi: token-budget-dependent).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct NewOrder {
+    pub market_id: String,
+    pub outcome: String,
+    pub side: OrderSide,
+    pub order_type: OrderType,
+    pub price: f64,
+    pub size: f64,
+    /// Polymarket: pin maker-only. Ignored on Kalshi.
+    pub post_only: Option<bool>,
+    /// Kalshi: only allow size reductions. Maps to `reduce_only=true`.
+    pub reduce_only: Option<bool>,
+    /// Kalshi-specific idempotency key.
+    pub client_order_id: Option<String>,
+    /// Unix seconds. Required for `OrderType::Gtc` orders that should expire.
+    pub expiration_ts: Option<i64>,
 }

--- a/engine/core/src/models/event.rs
+++ b/engine/core/src/models/event.rs
@@ -1,0 +1,37 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A grouping of related markets. On Kalshi, an Event is a single resolution
+/// (e.g. "Will Candidate X win State Y?") with one or more contracts. On
+/// Polymarket, an Event is the parent of one or more Markets sharing a common
+/// theme (e.g. "2028 US Presidential Election" with markets per candidate).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Event {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub series_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub market_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_ts: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_ts: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub volume: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_interest: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mutually_exclusive: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_updated_ts: Option<DateTime<Utc>>,
+}

--- a/engine/core/src/models/mod.rs
+++ b/engine/core/src/models/mod.rs
@@ -1,15 +1,21 @@
 mod crypto;
+mod event;
 mod market;
 mod order;
 mod orderbook;
 mod position;
+mod series;
 mod sport;
+mod tag;
 mod trade;
 
 pub use crypto::*;
+pub use event::*;
 pub use market::*;
 pub use order::*;
 pub use orderbook::*;
 pub use position::*;
+pub use series::*;
 pub use sport::*;
+pub use tag::*;
 pub use trade::*;

--- a/engine/core/src/models/order.rs
+++ b/engine/core/src/models/order.rs
@@ -131,6 +131,36 @@ pub struct Fill {
     pub created_at: DateTime<Utc>,
 }
 
+/// A user-facing trade row: distinct from `Fill` because it carries
+/// auxiliary fields some venues expose (realized PnL, on-chain tx hash,
+/// owner wallet) but others do not. Polymarket Data `/trades` returns
+/// these natively; Kalshi `/portfolio/fills` returns a subset, with
+/// `realized_pnl` and `tx_hash` left as `None`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct UserTrade {
+    pub id: String,
+    pub market_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub condition_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub asset_id: Option<String>,
+    pub side: OrderSide,
+    pub size: f64,
+    pub price: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<LiquidityRole>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fee: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub realized_pnl: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tx_hash: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    pub ts_ms: i64,
+}
+
 // TODO(fill-sim): Add local fill simulation for backtesting strategies offline.
 // Sketch of a FillEngine that simulates order execution against a local
 // orderbook copy:

--- a/engine/core/src/models/orderbook.rs
+++ b/engine/core/src/models/orderbook.rs
@@ -257,6 +257,19 @@ impl Orderbook {
     }
 }
 
+/// Top-of-book bid/ask + spread for a market outcome. Lighter than a full
+/// `Orderbook` — useful for liquidity scoring and PnL marks where only the
+/// best levels are needed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Spread {
+    pub bid: f64,
+    pub ask: f64,
+    pub spread: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ts_ms: Option<i64>,
+}
+
 /// A point-in-time L2 orderbook snapshot, used for historical orderbook data.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]

--- a/engine/core/src/models/series.rs
+++ b/engine/core/src/models/series.rs
@@ -1,0 +1,36 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A recurring family of events. Examples: a weekly inflation reading,
+/// a monthly nonfarm payrolls release, a regular sports season. On Kalshi,
+/// a Series is identified by `series_ticker` (e.g. `KXPRES`). On Polymarket,
+/// a Series wraps multiple Events with shared metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Series {
+    pub id: String,
+    pub title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frequency: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub settlement_sources: Vec<SettlementSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fee_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub volume: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_updated_ts: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SettlementSource {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}

--- a/engine/core/src/models/tag.rs
+++ b/engine/core/src/models/tag.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+/// A category or tag attached to a market or event. Used for filtering and
+/// search. Kalshi exposes tags via category-keyed lookups; Polymarket exposes
+/// per-market and per-event tag arrays.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Tag {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub slug: Option<String>,
+}

--- a/engine/core/src/models/trade.rs
+++ b/engine/core/src/models/trade.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::models::OrderSide;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublicTrade {
     pub proxy_wallet: String,
@@ -63,6 +65,18 @@ pub struct MarketTrade {
     pub no_price: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub taker_address: Option<String>,
+}
+
+/// Last public trade price + side + size for a market outcome. Distinct from
+/// the full `MarketTrade` tape: this is just "what just printed?" — common UI
+/// need that doesn't require the full trade history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct LastTrade {
+    pub price: f64,
+    pub side: OrderSide,
+    pub size: f64,
+    pub ts_ms: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/engine/exchanges/kalshi/src/exchange.rs
+++ b/engine/exchanges/kalshi/src/exchange.rs
@@ -1684,6 +1684,20 @@ impl Exchange for Kalshi {
             has_refresh_balance: false,
             has_websocket: self.auth.is_some() && !self.config.demo,
             has_fetch_orderbook_history: false,
+            has_fetch_events: false,
+            has_fetch_event: false,
+            has_fetch_orderbooks_batch: false,
+            has_fetch_series: false,
+            has_fetch_series_one: false,
+            has_fetch_midpoint: false,
+            has_fetch_midpoints_batch: false,
+            has_fetch_spread: false,
+            has_fetch_last_trade_price: false,
+            has_fetch_open_interest: false,
+            has_fetch_user_trades: false,
+            has_fetch_market_tags: false,
+            has_cancel_all_orders: false,
+            has_create_orders_batch: false,
         }
     }
 }

--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -3013,6 +3013,20 @@ impl Exchange for Polymarket {
             // Flag is false because historical data is now served from S3 Parquet
             // (backfilled via historical data pipeline), not proxied through CLOB.
             has_fetch_orderbook_history: false,
+            has_fetch_events: false,
+            has_fetch_event: false,
+            has_fetch_orderbooks_batch: false,
+            has_fetch_series: false,
+            has_fetch_series_one: false,
+            has_fetch_midpoint: false,
+            has_fetch_midpoints_batch: false,
+            has_fetch_spread: false,
+            has_fetch_last_trade_price: false,
+            has_fetch_open_interest: false,
+            has_fetch_user_trades: false,
+            has_fetch_market_tags: false,
+            has_cancel_all_orders: false,
+            has_create_orders_batch: false,
         }
     }
 }

--- a/engine/schema/src/main.rs
+++ b/engine/schema/src/main.rs
@@ -25,18 +25,26 @@ fn main() {
         schema_for!(px_core::OrderStatus),
         schema_for!(px_core::LiquidityRole),
         schema_for!(px_core::Fill),
+        schema_for!(px_core::UserTrade),
         // Models — position
         schema_for!(px_core::Position),
         // Models — orderbook
         schema_for!(px_core::Orderbook),
         schema_for!(px_core::OrderbookSnapshot),
+        schema_for!(px_core::Spread),
         schema_for!(px_core::PriceLevel),
         schema_for!(px_core::PriceLevelChange),
         schema_for!(px_core::PriceLevelSide),
         // Models — trade
         schema_for!(px_core::MarketTrade),
+        schema_for!(px_core::LastTrade),
         schema_for!(px_core::Candlestick),
         schema_for!(px_core::PriceHistoryInterval),
+        // Models — events / series / tags
+        schema_for!(px_core::Event),
+        schema_for!(px_core::Series),
+        schema_for!(px_core::SettlementSource),
+        schema_for!(px_core::Tag),
         // Exchange config params
         schema_for!(px_core::MarketStatusFilter),
         schema_for!(px_core::FetchMarketsParams),
@@ -47,6 +55,11 @@ fn main() {
         schema_for!(px_core::PriceHistoryRequest),
         schema_for!(px_core::TradesRequest),
         schema_for!(px_core::OrderbookHistoryRequest),
+        schema_for!(px_core::EventsRequest),
+        schema_for!(px_core::SeriesRequest),
+        schema_for!(px_core::MidpointRequest),
+        schema_for!(px_core::UserTradesRequest),
+        schema_for!(px_core::NewOrder),
         schema_for!(px_core::ExchangeInfo),
         // WebSocket types
         schema_for!(px_core::WsUpdate),

--- a/engine/sdk/src/lib.rs
+++ b/engine/sdk/src/lib.rs
@@ -190,4 +190,84 @@ impl ExchangeInner {
     pub async fn refresh_balance(&self) -> Result<(), OpenPxError> {
         dispatch!(self, refresh_balance)
     }
+
+    pub async fn fetch_events(
+        &self,
+        req: EventsRequest,
+    ) -> Result<(Vec<Event>, Option<String>), OpenPxError> {
+        dispatch!(self, fetch_events, req)
+    }
+
+    pub async fn fetch_event(&self, id: &str) -> Result<Event, OpenPxError> {
+        dispatch!(self, fetch_event, id)
+    }
+
+    pub async fn fetch_orderbooks_batch(
+        &self,
+        market_ids: Vec<String>,
+    ) -> Result<Vec<Orderbook>, OpenPxError> {
+        dispatch!(self, fetch_orderbooks_batch, market_ids)
+    }
+
+    pub async fn fetch_series(
+        &self,
+        req: SeriesRequest,
+    ) -> Result<(Vec<Series>, Option<String>), OpenPxError> {
+        dispatch!(self, fetch_series, req)
+    }
+
+    pub async fn fetch_series_one(&self, id: &str) -> Result<Series, OpenPxError> {
+        dispatch!(self, fetch_series_one, id)
+    }
+
+    pub async fn fetch_midpoint(&self, req: MidpointRequest) -> Result<f64, OpenPxError> {
+        dispatch!(self, fetch_midpoint, req)
+    }
+
+    pub async fn fetch_midpoints_batch(
+        &self,
+        market_ids: Vec<String>,
+    ) -> Result<HashMap<String, f64>, OpenPxError> {
+        dispatch!(self, fetch_midpoints_batch, market_ids)
+    }
+
+    pub async fn fetch_spread(&self, req: MidpointRequest) -> Result<Spread, OpenPxError> {
+        dispatch!(self, fetch_spread, req)
+    }
+
+    pub async fn fetch_last_trade_price(
+        &self,
+        req: MidpointRequest,
+    ) -> Result<LastTrade, OpenPxError> {
+        dispatch!(self, fetch_last_trade_price, req)
+    }
+
+    pub async fn fetch_open_interest(&self, market_id: &str) -> Result<f64, OpenPxError> {
+        dispatch!(self, fetch_open_interest, market_id)
+    }
+
+    pub async fn fetch_user_trades(
+        &self,
+        req: UserTradesRequest,
+    ) -> Result<(Vec<UserTrade>, Option<String>), OpenPxError> {
+        dispatch!(self, fetch_user_trades, req)
+    }
+
+    pub async fn fetch_market_tags(&self, market_id: &str) -> Result<Vec<Tag>, OpenPxError> {
+        dispatch!(self, fetch_market_tags, market_id)
+    }
+
+    pub async fn cancel_all_orders(
+        &self,
+        market_id: Option<&str>,
+    ) -> Result<Vec<Order>, OpenPxError> {
+        dispatch!(self, cancel_all_orders, market_id)
+    }
+
+    pub async fn create_orders_batch(
+        &self,
+        orders: Vec<NewOrder>,
+    ) -> Result<Vec<Order>, OpenPxError> {
+        dispatch!(self, create_orders_batch, orders)
+    }
 }

--- a/schema/openpx.schema.json
+++ b/schema/openpx.schema.json
@@ -211,9 +211,165 @@
       "title": "Candlestick",
       "type": "object"
     },
+    "Event": {
+      "description": "A grouping of related markets. On Kalshi, an Event is a single resolution (e.g. \"Will Candidate X win State Y?\") with one or more contracts. On Polymarket, an Event is the parent of one or more Markets sharing a common theme (e.g. \"2028 US Presidential Election\" with markets per candidate).",
+      "properties": {
+        "category": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "end_ts": {
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "last_updated_ts": {
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "market_ids": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mutually_exclusive": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "open_interest": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "series_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "slug": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "start_ts": {
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "volume": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "title"
+      ],
+      "title": "Event",
+      "type": "object"
+    },
+    "EventsRequest": {
+      "description": "Request for fetching events.",
+      "properties": {
+        "cursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "limit": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "min_close_ts": {
+          "description": "Unix seconds — only events closing at or after this timestamp.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "min_updated_ts": {
+          "description": "Unix seconds — only events updated at or after this timestamp.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "series_id": {
+          "description": "Filter by series ID / ticker.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "description": "Filter by lifecycle status — venue-specific values (e.g. `open`, `closed`, `settled` on Kalshi; `closed=true/false` on Polymarket).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "with_nested_markets": {
+          "description": "Include the events' nested `Market` objects when supported.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "title": "EventsRequest",
+      "type": "object"
+    },
     "ExchangeInfo": {
       "properties": {
         "has_approvals": {
+          "type": "boolean"
+        },
+        "has_cancel_all_orders": {
           "type": "boolean"
         },
         "has_cancel_order": {
@@ -222,13 +378,37 @@
         "has_create_order": {
           "type": "boolean"
         },
+        "has_create_orders_batch": {
+          "type": "boolean"
+        },
         "has_fetch_balance": {
+          "type": "boolean"
+        },
+        "has_fetch_event": {
+          "type": "boolean"
+        },
+        "has_fetch_events": {
           "type": "boolean"
         },
         "has_fetch_fills": {
           "type": "boolean"
         },
+        "has_fetch_last_trade_price": {
+          "type": "boolean"
+        },
+        "has_fetch_market_tags": {
+          "type": "boolean"
+        },
         "has_fetch_markets": {
+          "type": "boolean"
+        },
+        "has_fetch_midpoint": {
+          "type": "boolean"
+        },
+        "has_fetch_midpoints_batch": {
+          "type": "boolean"
+        },
+        "has_fetch_open_interest": {
           "type": "boolean"
         },
         "has_fetch_orderbook": {
@@ -237,19 +417,34 @@
         "has_fetch_orderbook_history": {
           "type": "boolean"
         },
+        "has_fetch_orderbooks_batch": {
+          "type": "boolean"
+        },
         "has_fetch_positions": {
           "type": "boolean"
         },
         "has_fetch_price_history": {
           "type": "boolean"
         },
+        "has_fetch_series": {
+          "type": "boolean"
+        },
+        "has_fetch_series_one": {
+          "type": "boolean"
+        },
         "has_fetch_server_time": {
+          "type": "boolean"
+        },
+        "has_fetch_spread": {
           "type": "boolean"
         },
         "has_fetch_trades": {
           "type": "boolean"
         },
         "has_fetch_user_activity": {
+          "type": "boolean"
+        },
+        "has_fetch_user_trades": {
           "type": "boolean"
         },
         "has_refresh_balance": {
@@ -267,18 +462,32 @@
       },
       "required": [
         "has_approvals",
+        "has_cancel_all_orders",
         "has_cancel_order",
         "has_create_order",
+        "has_create_orders_batch",
         "has_fetch_balance",
+        "has_fetch_event",
+        "has_fetch_events",
         "has_fetch_fills",
+        "has_fetch_last_trade_price",
+        "has_fetch_market_tags",
         "has_fetch_markets",
+        "has_fetch_midpoint",
+        "has_fetch_midpoints_batch",
+        "has_fetch_open_interest",
         "has_fetch_orderbook",
         "has_fetch_orderbook_history",
+        "has_fetch_orderbooks_batch",
         "has_fetch_positions",
         "has_fetch_price_history",
+        "has_fetch_series",
+        "has_fetch_series_one",
         "has_fetch_server_time",
+        "has_fetch_spread",
         "has_fetch_trades",
         "has_fetch_user_activity",
+        "has_fetch_user_trades",
         "has_refresh_balance",
         "has_websocket",
         "id",
@@ -463,6 +672,34 @@
           "type": "object"
         }
       ]
+    },
+    "LastTrade": {
+      "description": "Last public trade price + side + size for a market outcome. Distinct from the full `MarketTrade` tape: this is just \"what just printed?\" — common UI need that doesn't require the full trade history.",
+      "properties": {
+        "price": {
+          "format": "double",
+          "type": "number"
+        },
+        "side": {
+          "$ref": "#/definitions/OrderSide"
+        },
+        "size": {
+          "format": "double",
+          "type": "number"
+        },
+        "ts_ms": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "price",
+        "side",
+        "size",
+        "ts_ms"
+      ],
+      "title": "LastTrade",
+      "type": "object"
     },
     "LiquidityRole": {
       "enum": [
@@ -991,6 +1228,95 @@
       "title": "MarketType",
       "type": "string"
     },
+    "MidpointRequest": {
+      "description": "Request for midpoint / spread / last-trade-price methods. The same shape is reused for all three since they target the same outcome and accept the same identifier inputs.",
+      "properties": {
+        "market_id": {
+          "type": "string"
+        },
+        "outcome": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "token_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "market_id"
+      ],
+      "title": "MidpointRequest",
+      "type": "object"
+    },
+    "NewOrder": {
+      "description": "One order in a `create_orders_batch` call. Each venue caps the batch size (Polymarket: 15; Kalshi: token-budget-dependent).",
+      "properties": {
+        "client_order_id": {
+          "description": "Kalshi-specific idempotency key.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expiration_ts": {
+          "description": "Unix seconds. Required for `OrderType::Gtc` orders that should expire.",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "market_id": {
+          "type": "string"
+        },
+        "order_type": {
+          "$ref": "#/definitions/OrderType"
+        },
+        "outcome": {
+          "type": "string"
+        },
+        "post_only": {
+          "description": "Polymarket: pin maker-only. Ignored on Kalshi.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "price": {
+          "format": "double",
+          "type": "number"
+        },
+        "reduce_only": {
+          "description": "Kalshi: only allow size reductions. Maps to `reduce_only=true`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "side": {
+          "$ref": "#/definitions/OrderSide"
+        },
+        "size": {
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "required": [
+        "market_id",
+        "order_type",
+        "outcome",
+        "price",
+        "side",
+        "size"
+      ],
+      "title": "NewOrder",
+      "type": "object"
+    },
     "Order": {
       "properties": {
         "created_at": {
@@ -1073,7 +1399,6 @@
         "ioc",
         "fok"
       ],
-      "title": "OrderType",
       "type": "string"
     },
     "Orderbook": {
@@ -1394,6 +1719,104 @@
       ],
       "type": "string"
     },
+    "Series": {
+      "description": "A recurring family of events. Examples: a weekly inflation reading, a monthly nonfarm payrolls release, a regular sports season. On Kalshi, a Series is identified by `series_ticker` (e.g. `KXPRES`). On Polymarket, a Series wraps multiple Events with shared metadata.",
+      "properties": {
+        "category": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fee_type": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "frequency": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "last_updated_ts": {
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "settlement_sources": {
+          "default": [],
+          "items": {
+            "$ref": "#/definitions/SettlementSource"
+          },
+          "type": "array"
+        },
+        "tags": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "type": "string"
+        },
+        "volume": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "title"
+      ],
+      "title": "Series",
+      "type": "object"
+    },
+    "SeriesRequest": {
+      "description": "Request for fetching series.",
+      "properties": {
+        "category": {
+          "description": "Filter by category (e.g. `Politics`, `Sports`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "cursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "include_volume": {
+          "description": "Include traded volume in the response when the venue supports it.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "limit": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "title": "SeriesRequest",
+      "type": "object"
+    },
     "SessionEvent": {
       "description": "Connection-level events, emitted on a channel separate from `WsUpdate` so a reconnect is observable as a single global signal rather than per-market.",
       "oneOf": [
@@ -1511,6 +1934,78 @@
       ],
       "title": "SessionEvent"
     },
+    "SettlementSource": {
+      "properties": {
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "title": "SettlementSource",
+      "type": "object"
+    },
+    "Spread": {
+      "description": "Top-of-book bid/ask + spread for a market outcome. Lighter than a full `Orderbook` — useful for liquidity scoring and PnL marks where only the best levels are needed.",
+      "properties": {
+        "ask": {
+          "format": "double",
+          "type": "number"
+        },
+        "bid": {
+          "format": "double",
+          "type": "number"
+        },
+        "spread": {
+          "format": "double",
+          "type": "number"
+        },
+        "ts_ms": {
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "ask",
+        "bid",
+        "spread"
+      ],
+      "title": "Spread",
+      "type": "object"
+    },
+    "Tag": {
+      "description": "A category or tag attached to a market or event. Used for filtering and search. Kalshi exposes tags via category-keyed lookups; Polymarket exposes per-market and per-event tag arrays.",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "slug": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ],
+      "title": "Tag",
+      "type": "object"
+    },
     "TradesRequest": {
       "description": "Request for fetching recent public trades (\"tape\") for a market outcome.",
       "properties": {
@@ -1574,6 +2069,150 @@
         "market_id"
       ],
       "title": "TradesRequest",
+      "type": "object"
+    },
+    "UserTrade": {
+      "description": "A user-facing trade row: distinct from `Fill` because it carries auxiliary fields some venues expose (realized PnL, on-chain tx hash, owner wallet) but others do not. Polymarket Data `/trades` returns these natively; Kalshi `/portfolio/fills` returns a subset, with `realized_pnl` and `tx_hash` left as `None`.",
+      "properties": {
+        "asset_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "condition_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fee": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "id": {
+          "type": "string"
+        },
+        "market_id": {
+          "type": "string"
+        },
+        "owner": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "price": {
+          "format": "double",
+          "type": "number"
+        },
+        "realized_pnl": {
+          "format": "double",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "role": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LiquidityRole"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "side": {
+          "$ref": "#/definitions/OrderSide"
+        },
+        "size": {
+          "format": "double",
+          "type": "number"
+        },
+        "ts_ms": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "tx_hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "market_id",
+        "price",
+        "side",
+        "size",
+        "ts_ms"
+      ],
+      "title": "UserTrade",
+      "type": "object"
+    },
+    "UserTradesRequest": {
+      "description": "Request for `fetch_user_trades`.",
+      "properties": {
+        "cursor": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "end_ts": {
+          "description": "Unix seconds (inclusive)",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "limit": {
+          "format": "uint",
+          "minimum": 0.0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "market_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "side": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OrderSide"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "start_ts": {
+          "description": "Unix seconds (inclusive)",
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "user_address": {
+          "description": "`None` = caller's own trades (auth required on both venues). `Some(addr)` = public lookup for `addr` (Polymarket only; Kalshi returns `NotSupported`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "title": "UserTradesRequest",
       "type": "object"
     },
     "WsUpdate": {

--- a/sdks/python/python/openpx/_models.py
+++ b/sdks/python/python/openpx/_models.py
@@ -55,20 +55,72 @@ class Candlestick(BaseModel):
     )
 
 
+class Event(BaseModel):
+    category: str | None = None
+    description: str | None = None
+    end_ts: AwareDatetime | None = None
+    id: str
+    last_updated_ts: AwareDatetime | None = None
+    market_ids: list[str] | None = []
+    mutually_exclusive: bool | None = None
+    open_interest: float | None = None
+    series_id: str | None = None
+    slug: str | None = None
+    start_ts: AwareDatetime | None = None
+    status: str | None = None
+    title: str
+    volume: float | None = None
+
+
+class EventsRequest(BaseModel):
+    cursor: str | None = None
+    limit: conint(ge=0) | None = None
+    min_close_ts: int | None = Field(
+        None,
+        description="Unix seconds — only events closing at or after this timestamp.",
+    )
+    min_updated_ts: int | None = Field(
+        None,
+        description="Unix seconds — only events updated at or after this timestamp.",
+    )
+    series_id: str | None = Field(None, description="Filter by series ID / ticker.")
+    status: str | None = Field(
+        None,
+        description="Filter by lifecycle status — venue-specific values (e.g. `open`, `closed`, `settled` on Kalshi; `closed=true/false` on Polymarket).",
+    )
+    with_nested_markets: bool | None = Field(
+        None, description="Include the events' nested `Market` objects when supported."
+    )
+
+
 class ExchangeInfo(BaseModel):
     has_approvals: bool
+    has_cancel_all_orders: bool
     has_cancel_order: bool
     has_create_order: bool
+    has_create_orders_batch: bool
     has_fetch_balance: bool
+    has_fetch_event: bool
+    has_fetch_events: bool
     has_fetch_fills: bool
+    has_fetch_last_trade_price: bool
+    has_fetch_market_tags: bool
     has_fetch_markets: bool
+    has_fetch_midpoint: bool
+    has_fetch_midpoints_batch: bool
+    has_fetch_open_interest: bool
     has_fetch_orderbook: bool
     has_fetch_orderbook_history: bool
+    has_fetch_orderbooks_batch: bool
     has_fetch_positions: bool
     has_fetch_price_history: bool
+    has_fetch_series: bool
+    has_fetch_series_one: bool
     has_fetch_server_time: bool
+    has_fetch_spread: bool
     has_fetch_trades: bool
     has_fetch_user_activity: bool
+    has_fetch_user_trades: bool
     has_refresh_balance: bool
     has_websocket: bool
     id: str
@@ -148,6 +200,12 @@ class MarketType(Enum):
     scalar = "scalar"
 
 
+class MidpointRequest(BaseModel):
+    market_id: str
+    outcome: str | None = None
+    token_id: str | None = None
+
+
 class OrderSide(Enum):
     buy = "buy"
     sell = "sell"
@@ -222,6 +280,18 @@ class PriceLevelSide(Enum):
     ask = "ask"
 
 
+class SeriesRequest(BaseModel):
+    category: str | None = Field(
+        None, description="Filter by category (e.g. `Politics`, `Sports`)."
+    )
+    cursor: str | None = None
+    include_volume: bool | None = Field(
+        None,
+        description="Include traded volume in the response when the venue supports it.",
+    )
+    limit: conint(ge=0) | None = None
+
+
 class Kind(Enum):
     Connected = "Connected"
 
@@ -283,6 +353,24 @@ class SessionEvent(
     )
 
 
+class SettlementSource(BaseModel):
+    name: str | None = None
+    url: str | None = None
+
+
+class Spread(BaseModel):
+    ask: float
+    bid: float
+    spread: float
+    ts_ms: int | None = None
+
+
+class Tag(BaseModel):
+    id: str
+    name: str
+    slug: str | None = None
+
+
 class TradesRequest(BaseModel):
     cursor: str | None = Field(
         None, description="Opaque pagination cursor from a previous response."
@@ -300,6 +388,35 @@ class TradesRequest(BaseModel):
     outcome: str | None = None
     start_ts: int | None = Field(None, description="Unix seconds (inclusive)")
     token_id: str | None = None
+
+
+class UserTrade(BaseModel):
+    asset_id: str | None = None
+    condition_id: str | None = None
+    fee: float | None = None
+    id: str
+    market_id: str
+    owner: str | None = None
+    price: float
+    realized_pnl: float | None = None
+    role: LiquidityRole | None = None
+    side: OrderSide
+    size: float
+    ts_ms: int
+    tx_hash: str | None = None
+
+
+class UserTradesRequest(BaseModel):
+    cursor: str | None = None
+    end_ts: int | None = Field(None, description="Unix seconds (inclusive)")
+    limit: conint(ge=0) | None = None
+    market_id: str | None = None
+    side: OrderSide | None = None
+    start_ts: int | None = Field(None, description="Unix seconds (inclusive)")
+    user_address: str | None = Field(
+        None,
+        description="`None` = caller's own trades (auth required on both venues). `Some(addr)` = public lookup for `addr` (Polymarket only; Kalshi returns `NotSupported`).",
+    )
 
 
 class Kind5(Enum):
@@ -397,6 +514,13 @@ class Fill(BaseModel):
     price: float
     side: OrderSide
     size: float
+
+
+class LastTrade(BaseModel):
+    price: float
+    side: OrderSide
+    size: float
+    ts_ms: int
 
 
 class Market(BaseModel):
@@ -506,6 +630,29 @@ class Market(BaseModel):
     volume_24h: float | None = Field(None, description="24-hour trading volume (USD)")
 
 
+class NewOrder(BaseModel):
+    client_order_id: str | None = Field(
+        None, description="Kalshi-specific idempotency key."
+    )
+    expiration_ts: int | None = Field(
+        None,
+        description="Unix seconds. Required for `OrderType::Gtc` orders that should expire.",
+    )
+    market_id: str
+    order_type: OrderType
+    outcome: str
+    post_only: bool | None = Field(
+        None, description="Polymarket: pin maker-only. Ignored on Kalshi."
+    )
+    price: float
+    reduce_only: bool | None = Field(
+        None,
+        description="Kalshi: only allow size reductions. Maps to `reduce_only=true`.",
+    )
+    side: OrderSide
+    size: float
+
+
 class Order(BaseModel):
     created_at: AwareDatetime
     filled: float
@@ -528,6 +675,18 @@ class PriceLevelChange(BaseModel):
     price: Number
     side: PriceLevelSide
     size: float
+
+
+class Series(BaseModel):
+    category: str | None = None
+    fee_type: str | None = None
+    frequency: str | None = None
+    id: str
+    last_updated_ts: AwareDatetime | None = None
+    settlement_sources: list[SettlementSource] | None = Field([], validate_default=True)
+    tags: list[str] | None = []
+    title: str
+    volume: float | None = None
 
 
 class WsUpdate2(BaseModel):

--- a/sdks/typescript/types/models.d.ts
+++ b/sdks/typescript/types/models.d.ts
@@ -54,11 +54,6 @@ export type MarketType = "binary" | "categorical" | "scalar";
  */
 export type MarketStatus = "active" | "closed" | "resolved";
 /**
- * This interface was referenced by `OpenPX`'s JSON-Schema
- * via the `definition` "OrderStatus".
- */
-export type OrderStatus = "pending" | "open" | "filled" | "partially_filled" | "cancelled" | "rejected";
-/**
  * Order time-in-force / execution type.
  *
  * Normalized across all exchanges: - `Gtc` (good-til-cancelled) — rests on the book until filled or cancelled. - `Ioc` (immediate-or-cancel) — fills what it can immediately, cancels the rest. - `Fok` (fill-or-kill) — must fill entirely in one shot or is cancelled.
@@ -67,6 +62,11 @@ export type OrderStatus = "pending" | "open" | "filled" | "partially_filled" | "
  * via the `definition` "OrderType".
  */
 export type OrderType = "gtc" | "ioc" | "fok";
+/**
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "OrderStatus".
+ */
+export type OrderStatus = "pending" | "open" | "filled" | "partially_filled" | "cancelled" | "rejected";
 /**
  * This interface was referenced by `OpenPX`'s JSON-Schema
  * via the `definition` "number".
@@ -256,23 +256,91 @@ export interface Candlestick {
   [k: string]: unknown;
 }
 /**
+ * A grouping of related markets. On Kalshi, an Event is a single resolution (e.g. "Will Candidate X win State Y?") with one or more contracts. On Polymarket, an Event is the parent of one or more Markets sharing a common theme (e.g. "2028 US Presidential Election" with markets per candidate).
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "Event".
+ */
+export interface Event {
+  category?: string | null;
+  description?: string | null;
+  end_ts?: string | null;
+  id: string;
+  last_updated_ts?: string | null;
+  market_ids?: string[];
+  mutually_exclusive?: boolean | null;
+  open_interest?: number | null;
+  series_id?: string | null;
+  slug?: string | null;
+  start_ts?: string | null;
+  status?: string | null;
+  title: string;
+  volume?: number | null;
+  [k: string]: unknown;
+}
+/**
+ * Request for fetching events.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "EventsRequest".
+ */
+export interface EventsRequest {
+  cursor?: string | null;
+  limit?: number | null;
+  /**
+   * Unix seconds — only events closing at or after this timestamp.
+   */
+  min_close_ts?: number | null;
+  /**
+   * Unix seconds — only events updated at or after this timestamp.
+   */
+  min_updated_ts?: number | null;
+  /**
+   * Filter by series ID / ticker.
+   */
+  series_id?: string | null;
+  /**
+   * Filter by lifecycle status — venue-specific values (e.g. `open`, `closed`, `settled` on Kalshi; `closed=true/false` on Polymarket).
+   */
+  status?: string | null;
+  /**
+   * Include the events' nested `Market` objects when supported.
+   */
+  with_nested_markets?: boolean | null;
+  [k: string]: unknown;
+}
+/**
  * This interface was referenced by `OpenPX`'s JSON-Schema
  * via the `definition` "ExchangeInfo".
  */
 export interface ExchangeInfo {
   has_approvals: boolean;
+  has_cancel_all_orders: boolean;
   has_cancel_order: boolean;
   has_create_order: boolean;
+  has_create_orders_batch: boolean;
   has_fetch_balance: boolean;
+  has_fetch_event: boolean;
+  has_fetch_events: boolean;
   has_fetch_fills: boolean;
+  has_fetch_last_trade_price: boolean;
+  has_fetch_market_tags: boolean;
   has_fetch_markets: boolean;
+  has_fetch_midpoint: boolean;
+  has_fetch_midpoints_batch: boolean;
+  has_fetch_open_interest: boolean;
   has_fetch_orderbook: boolean;
   has_fetch_orderbook_history: boolean;
+  has_fetch_orderbooks_batch: boolean;
   has_fetch_positions: boolean;
   has_fetch_price_history: boolean;
+  has_fetch_series: boolean;
+  has_fetch_series_one: boolean;
   has_fetch_server_time: boolean;
+  has_fetch_spread: boolean;
   has_fetch_trades: boolean;
   has_fetch_user_activity: boolean;
+  has_fetch_user_trades: boolean;
   has_refresh_balance: boolean;
   has_websocket: boolean;
   id: string;
@@ -340,6 +408,19 @@ export interface Fill {
   price: number;
   side: OrderSide;
   size: number;
+  [k: string]: unknown;
+}
+/**
+ * Last public trade price + side + size for a market outcome. Distinct from the full `MarketTrade` tape: this is just "what just printed?" — common UI need that doesn't require the full trade history.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "LastTrade".
+ */
+export interface LastTrade {
+  price: number;
+  side: OrderSide;
+  size: number;
+  ts_ms: number;
   [k: string]: unknown;
 }
 /**
@@ -614,6 +695,49 @@ export interface MarketTrade {
   [k: string]: unknown;
 }
 /**
+ * Request for midpoint / spread / last-trade-price methods. The same shape is reused for all three since they target the same outcome and accept the same identifier inputs.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "MidpointRequest".
+ */
+export interface MidpointRequest {
+  market_id: string;
+  outcome?: string | null;
+  token_id?: string | null;
+  [k: string]: unknown;
+}
+/**
+ * One order in a `create_orders_batch` call. Each venue caps the batch size (Polymarket: 15; Kalshi: token-budget-dependent).
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "NewOrder".
+ */
+export interface NewOrder {
+  /**
+   * Kalshi-specific idempotency key.
+   */
+  client_order_id?: string | null;
+  /**
+   * Unix seconds. Required for `OrderType::Gtc` orders that should expire.
+   */
+  expiration_ts?: number | null;
+  market_id: string;
+  order_type: OrderType;
+  outcome: string;
+  /**
+   * Polymarket: pin maker-only. Ignored on Kalshi.
+   */
+  post_only?: boolean | null;
+  price: number;
+  /**
+   * Kalshi: only allow size reductions. Maps to `reduce_only=true`.
+   */
+  reduce_only?: boolean | null;
+  side: OrderSide;
+  size: number;
+  [k: string]: unknown;
+}
+/**
  * This interface was referenced by `OpenPX`'s JSON-Schema
  * via the `definition` "Order".
  */
@@ -745,6 +869,77 @@ export interface PriceLevelChange {
   [k: string]: unknown;
 }
 /**
+ * A recurring family of events. Examples: a weekly inflation reading, a monthly nonfarm payrolls release, a regular sports season. On Kalshi, a Series is identified by `series_ticker` (e.g. `KXPRES`). On Polymarket, a Series wraps multiple Events with shared metadata.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "Series".
+ */
+export interface Series {
+  category?: string | null;
+  fee_type?: string | null;
+  frequency?: string | null;
+  id: string;
+  last_updated_ts?: string | null;
+  settlement_sources?: SettlementSource[];
+  tags?: string[];
+  title: string;
+  volume?: number | null;
+  [k: string]: unknown;
+}
+/**
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "SettlementSource".
+ */
+export interface SettlementSource {
+  name?: string | null;
+  url?: string | null;
+  [k: string]: unknown;
+}
+/**
+ * Request for fetching series.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "SeriesRequest".
+ */
+export interface SeriesRequest {
+  /**
+   * Filter by category (e.g. `Politics`, `Sports`).
+   */
+  category?: string | null;
+  cursor?: string | null;
+  /**
+   * Include traded volume in the response when the venue supports it.
+   */
+  include_volume?: boolean | null;
+  limit?: number | null;
+  [k: string]: unknown;
+}
+/**
+ * Top-of-book bid/ask + spread for a market outcome. Lighter than a full `Orderbook` — useful for liquidity scoring and PnL marks where only the best levels are needed.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "Spread".
+ */
+export interface Spread {
+  ask: number;
+  bid: number;
+  spread: number;
+  ts_ms?: number | null;
+  [k: string]: unknown;
+}
+/**
+ * A category or tag attached to a market or event. Used for filtering and search. Kalshi exposes tags via category-keyed lookups; Polymarket exposes per-market and per-event tag arrays.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "Tag".
+ */
+export interface Tag {
+  id: string;
+  name: string;
+  slug?: string | null;
+  [k: string]: unknown;
+}
+/**
  * Request for fetching recent public trades ("tape") for a market outcome.
  *
  * This interface was referenced by `OpenPX`'s JSON-Schema
@@ -777,5 +972,52 @@ export interface TradesRequest {
    */
   start_ts?: number | null;
   token_id?: string | null;
+  [k: string]: unknown;
+}
+/**
+ * A user-facing trade row: distinct from `Fill` because it carries auxiliary fields some venues expose (realized PnL, on-chain tx hash, owner wallet) but others do not. Polymarket Data `/trades` returns these natively; Kalshi `/portfolio/fills` returns a subset, with `realized_pnl` and `tx_hash` left as `None`.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "UserTrade".
+ */
+export interface UserTrade {
+  asset_id?: string | null;
+  condition_id?: string | null;
+  fee?: number | null;
+  id: string;
+  market_id: string;
+  owner?: string | null;
+  price: number;
+  realized_pnl?: number | null;
+  role?: LiquidityRole | null;
+  side: OrderSide;
+  size: number;
+  ts_ms: number;
+  tx_hash?: string | null;
+  [k: string]: unknown;
+}
+/**
+ * Request for `fetch_user_trades`.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "UserTradesRequest".
+ */
+export interface UserTradesRequest {
+  cursor?: string | null;
+  /**
+   * Unix seconds (inclusive)
+   */
+  end_ts?: number | null;
+  limit?: number | null;
+  market_id?: string | null;
+  side?: OrderSide | null;
+  /**
+   * Unix seconds (inclusive)
+   */
+  start_ts?: number | null;
+  /**
+   * `None` = caller's own trades (auth required on both venues). `Some(addr)` = public lookup for `addr` (Polymarket only; Kalshi returns `NotSupported`).
+   */
+  user_address?: string | null;
   [k: string]: unknown;
 }


### PR DESCRIPTION
## Summary

Scaffolds the trait surface for 14 new unified \`Exchange\` methods identified by the 2026-04-27 Kalshi × Polymarket overlap analysis (\`maintenance/research/2026-04-27-kalshi-polymarket-overlap.md\`). Every method defaults to \`Err(NotSupported)\`; both exchange \`describe()\` overrides set the new \`has_*\` flags to \`false\`. **Per-venue implementations land in follow-up PRs (Batches 2–5)**, each independently mergeable on top of this branch.

## What's added

**14 new trait methods** (all return \`Err(NotSupported)\` by default):

| Method | Rationale |
|---|---|
| \`fetch_events\`, \`fetch_event\` | Both venues group markets into events |
| \`fetch_orderbooks_batch\` | Both expose multi-market book endpoints — major HFT/MM latency win |
| \`fetch_series\`, \`fetch_series_one\` | Recurring event families on both venues |
| \`fetch_midpoint\`, \`fetch_midpoints_batch\` | Polymarket \`/midpoint(s)\` native; Kalshi derives from book |
| \`fetch_spread\` | Top-of-book spread (cheap mark-price proxy) |
| \`fetch_last_trade_price\` | Most-recent print without the full trade tape |
| \`fetch_open_interest\` | Polymarket Data \`/oi\`; Kalshi field on \`/markets/{ticker}\` |
| \`fetch_user_trades\` | Distinct from \`fetch_fills\` — carries \`realized_pnl\`, \`tx_hash\`, \`owner\` |
| \`fetch_market_tags\` | Category/tag metadata for filtering UIs |
| \`cancel_all_orders\` | Both venues have explicit batch-cancel verbs |
| \`create_orders_batch\` | Both have batch-create; Polymarket caps at 15 |

**5 new request types** (in \`engine/core/src/exchange/traits.rs\`): \`EventsRequest\`, \`SeriesRequest\`, \`MidpointRequest\`, \`UserTradesRequest\`, \`NewOrder\`. \`MidpointRequest\` is reused by \`fetch_spread\` and \`fetch_last_trade_price\`.

**6 new model types**:
- New files: \`engine/core/src/models/{event,series,tag}.rs\`
- Extensions: \`models/orderbook.rs::Spread\`, \`models/trade.rs::LastTrade\`, \`models/order.rs::UserTrade\`

**14 new \`has_*\` fields** on \`ExchangeInfo\`, defaulted to \`false\` in the trait + both exchange overrides.

**SDK facade** (\`engine/sdk/src/lib.rs\`): 14 new \`dispatch!\` wrappers.

**Schema export** (\`engine/schema/src/main.rs\`): registers the 11 new types + \`SettlementSource\`. Final schema has 46 type definitions (was 35).

**Generated SDK files** (committed in \`7134fc2\` per the bot's sync invariant):
- \`schema/openpx.schema.json\` (+641)
- \`sdks/python/python/openpx/_models.py\` (+159)
- \`sdks/typescript/types/models.d.ts\` (+252)
- \`docs/reference/types.mdx\` (+188)

## Why \`UserTrade\` is distinct from \`Fill\`

Two different shapes from two different sources:
- \`Fill\` = exchange-side execution row (Kalshi \`/portfolio/fills\`).
- \`UserTrade\` = user-facing aggregated trade row (Polymarket Data \`/trades\`) with on-chain fields like \`tx_hash\` and a \`realized_pnl\` that don't fit \`Fill\`.

The two coexist; Kalshi populates the \`UserTrade\` subset it has and leaves \`realized_pnl\` + \`tx_hash\` as \`None\`.

## Test plan

- [x] \`cargo fmt --all --check\` clean
- [x] \`cargo check --workspace\` clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test --workspace\` green
- [x] \`cargo test -p px-core --test manifest_coverage\` green (no new \`.get(...)\` reads in this PR — pure trait scaffolding)
- [x] \`just sync-all\` produces zero diff after commit (\`just check-sync\` green)
- [x] \`python -m py_compile sdks/python/python/openpx/_models.py\` clean
- [x] All 12 new types present in both Python (\`_models.py\`) and TypeScript (\`models.d.ts\`)

## Stack & next steps

- **Independent of the V2 migration** (#54, #55) — this trait scaffolding can land in either order with respect to the V2 stack.
- Follow-ups (each its own PR, all stacked on this branch):
  - Batch 2: \`fetch_events\`, \`fetch_event\`, \`fetch_series\`, \`fetch_series_one\`, \`fetch_market_tags\` impls
  - Batch 3: pricing/books impls (6 methods)
  - Batch 4: \`fetch_user_trades\` impl
  - Batch 5: \`cancel_all_orders\`, \`create_orders_batch\` impls (funds-moving — CODEOWNERS gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)