### PR TITLE
feat(exchanges): implement events / series / tags methods on both venues (Batch 2)

### DIFF
--- a/docs/api/events/fetch-event.mdx
+++ b/docs/api/events/fetch-event.mdx
@@ -1,0 +1,64 @@
+---
+title: "fetch_event"
+sidebarTitle: "Fetch event"
+openapi: GET /v1/events/fetch_event
+playground: simple
+description: "Look up a single event by ID or slug."
+---
+
+Looks up one event. Pass a Kalshi `event_ticker`, a Polymarket UUID, or a
+Polymarket slug — the venue is auto-detected.
+
+## Parameters
+
+<ParamField path="id" type="string" required>
+  Event identifier. Kalshi: `event_ticker` (e.g. `KXPRES-2028`).
+  Polymarket: either a UUID-shaped event ID or a URL slug. The
+  Polymarket implementation dispatches between `/events/{id}` and
+  `/events/slug/{slug}` based on a length+charset heuristic.
+</ParamField>
+
+## Returns
+
+The matching `Event`. See [`fetch_events`](/api/events/fetch-events) for the
+full field list.
+
+<RequestExample>
+
+```rust Rust
+let event = ex.fetch_event("KXPRES-2028").await?;
+println!("{} ({} markets)", event.title, event.market_ids.len());
+```
+
+```python Python
+event = ex.fetch_event("KXPRES-2028")
+```
+
+```typescript TypeScript
+const event = await ex.fetchEvent("KXPRES-2028");
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+{
+  "id": "KXPRES-2028",
+  "slug": null,
+  "title": "2028 US Presidential Election",
+  "description": "Winning candidate",
+  "category": null,
+  "series_id": "KXPRES",
+  "status": null,
+  "market_ids": ["KXPRES-2028-DEM", "KXPRES-2028-REP", "KXPRES-2028-IND"],
+  "start_ts": null,
+  "end_ts": "2028-11-07T00:00:00Z",
+  "volume": null,
+  "open_interest": null,
+  "mutually_exclusive": true,
+  "last_updated_ts": "2026-04-26T12:34:56Z"
+}
+```
+
+</ResponseExample>

--- a/docs/api/events/fetch-events.mdx
+++ b/docs/api/events/fetch-events.mdx
@@ -1,0 +1,122 @@
+---
+title: "fetch_events"
+sidebarTitle: "Fetch events"
+openapi: GET /v1/events/fetch_events
+playground: simple
+description: "Page through events that group related markets."
+---
+
+An event groups one or more markets that share a resolution (Kalshi: a single
+`event_ticker` like `KXPRES-2028`) or theme (Polymarket: an event linking
+multiple `Market` objects).
+
+## Parameters
+
+<ParamField path="limit" type="usize?">
+  Per-page limit. Capped at 200 (Kalshi) / 500 (Polymarket).
+</ParamField>
+
+<ParamField path="cursor" type="string?">
+  Opaque cursor returned from a prior call. Polymarket uses keyset pagination
+  internally; pass through unchanged.
+</ParamField>
+
+<ParamField path="status" type="string?">
+  Lifecycle filter. Kalshi accepts `unopened`, `open`, `closed`, `settled`.
+  Polymarket maps `open` → `closed=false` and `closed` → `closed=true`.
+</ParamField>
+
+<ParamField path="series_id" type="string?">
+  Restrict to events under a given series.
+</ParamField>
+
+<ParamField path="with_nested_markets" type="bool?">
+  When true, the venue returns the events' nested `Market` objects in the
+  same response. Kalshi only.
+</ParamField>
+
+<ParamField path="min_close_ts" type="i64?">
+  Unix seconds. Only events closing at or after this timestamp.
+</ParamField>
+
+<ParamField path="min_updated_ts" type="i64?">
+  Unix seconds. Only events updated at or after this timestamp.
+</ParamField>
+
+## Returns
+
+<ResponseField name="events" type="Event[]">
+  One page of events.
+
+  <Expandable title="Event">
+    <ResponseField name="id" type="string">Native ID — Kalshi `event_ticker` or Polymarket UUID.</ResponseField>
+    <ResponseField name="slug" type="string?">URL-safe identifier (Polymarket).</ResponseField>
+    <ResponseField name="title" type="string" />
+    <ResponseField name="description" type="string?" />
+    <ResponseField name="category" type="string?" />
+    <ResponseField name="series_id" type="string?" />
+    <ResponseField name="status" type="string?">Venue-specific (`open`, `closed`, `settled`, …).</ResponseField>
+    <ResponseField name="market_ids" type="string[]">Member markets when known.</ResponseField>
+    <ResponseField name="start_ts" type="DateTime?" />
+    <ResponseField name="end_ts" type="DateTime?" />
+    <ResponseField name="volume" type="f64?" />
+    <ResponseField name="open_interest" type="f64?" />
+    <ResponseField name="mutually_exclusive" type="bool?">True when only one member market can resolve Yes (e.g. neg-risk).</ResponseField>
+    <ResponseField name="last_updated_ts" type="DateTime?" />
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="cursor" type="string?">
+  Opaque pagination cursor. `null` on the last page.
+</ResponseField>
+
+<RequestExample>
+
+```rust Rust
+use openpx::EventsRequest;
+
+let req = EventsRequest {
+    limit: Some(50),
+    status: Some("open".into()),
+    ..Default::default()
+};
+let (events, cursor) = ex.fetch_events(req).await?;
+```
+
+```python Python
+events, cursor = ex.fetch_events(limit=50, status="open")
+```
+
+```typescript TypeScript
+const { events, cursor } = await ex.fetchEvents({ limit: 50, status: "open" });
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+{
+  "events": [
+    {
+      "id": "KXPRES-2028",
+      "slug": null,
+      "title": "2028 US Presidential Election",
+      "description": "Winning candidate",
+      "category": null,
+      "series_id": "KXPRES",
+      "status": null,
+      "market_ids": ["KXPRES-2028-DEM", "KXPRES-2028-REP"],
+      "start_ts": null,
+      "end_ts": "2028-11-07T00:00:00Z",
+      "volume": null,
+      "open_interest": null,
+      "mutually_exclusive": true,
+      "last_updated_ts": "2026-04-26T12:34:56Z"
+    }
+  ],
+  "cursor": "eyJsYXN0SWQiOiJLWFBSRVMtMjAyOCJ9"
+}
+```
+
+</ResponseExample>

--- a/docs/api/series/fetch-series-one.mdx
+++ b/docs/api/series/fetch-series-one.mdx
@@ -1,0 +1,52 @@
+---
+title: "fetch_series_one"
+sidebarTitle: "Fetch series (one)"
+openapi: GET /v1/series/fetch_series_one
+playground: simple
+description: "Look up a single series by ID or ticker."
+---
+
+## Parameters
+
+<ParamField path="id" type="string" required>
+  Series identifier. Kalshi: `series_ticker` (e.g. `KXSPX`). Polymarket: UUID.
+</ParamField>
+
+## Returns
+
+The matching `Series`. See [`fetch_series`](/api/series/fetch-series) for the
+full field list. Kalshi includes `volume` automatically.
+
+<RequestExample>
+
+```rust Rust
+let series = ex.fetch_series_one("KXSPX").await?;
+```
+
+```python Python
+series = ex.fetch_series_one("KXSPX")
+```
+
+```typescript TypeScript
+const series = await ex.fetchSeriesOne("KXSPX");
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+{
+  "id": "KXSPX",
+  "title": "S&P 500 Daily",
+  "category": "Economics",
+  "frequency": "daily",
+  "tags": ["finance", "indices"],
+  "settlement_sources": [{ "name": "S&P Dow Jones", "url": "https://www.spglobal.com" }],
+  "fee_type": "quadratic",
+  "volume": 1234567.89,
+  "last_updated_ts": "2026-04-27T00:00:00Z"
+}
+```
+
+</ResponseExample>

--- a/docs/api/series/fetch-series.mdx
+++ b/docs/api/series/fetch-series.mdx
@@ -1,0 +1,101 @@
+---
+title: "fetch_series"
+sidebarTitle: "Fetch series"
+openapi: GET /v1/series/fetch_series
+playground: simple
+description: "Page through recurring event families."
+---
+
+A series is a recurring family of events — a weekly inflation print, a monthly
+nonfarm payrolls release, a regular sports season, etc. On Kalshi a series is
+identified by `series_ticker` (e.g. `KXPRES`); on Polymarket each series wraps
+multiple events.
+
+## Parameters
+
+<ParamField path="limit" type="usize?">
+  Per-page limit. Capped at 200 (Kalshi) / 500 (Polymarket).
+</ParamField>
+
+<ParamField path="cursor" type="string?">
+  Opaque cursor returned from a prior call.
+</ParamField>
+
+<ParamField path="category" type="string?">
+  Filter by category (e.g. `Politics`, `Economics`).
+</ParamField>
+
+<ParamField path="include_volume" type="bool?">
+  Kalshi only. Adds `volume` to each series.
+</ParamField>
+
+## Returns
+
+<ResponseField name="series" type="Series[]">
+  One page of series.
+
+  <Expandable title="Series">
+    <ResponseField name="id" type="string" />
+    <ResponseField name="title" type="string" />
+    <ResponseField name="category" type="string?" />
+    <ResponseField name="frequency" type="string?">e.g. `weekly`, `monthly`, `daily`.</ResponseField>
+    <ResponseField name="tags" type="string[]">Free-form Kalshi tags.</ResponseField>
+    <ResponseField name="settlement_sources" type="SettlementSource[]">Kalshi only — links to oracle/source URLs.</ResponseField>
+    <ResponseField name="fee_type" type="string?">Kalshi only — `quadratic`, `flat`, etc.</ResponseField>
+    <ResponseField name="volume" type="f64?" />
+    <ResponseField name="last_updated_ts" type="DateTime?" />
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="cursor" type="string?">
+  `null` on the last page.
+</ResponseField>
+
+<RequestExample>
+
+```rust Rust
+use openpx::SeriesRequest;
+
+let req = SeriesRequest {
+    limit: Some(50),
+    category: Some("Economics".into()),
+    include_volume: Some(true),
+    ..Default::default()
+};
+let (series, cursor) = ex.fetch_series(req).await?;
+```
+
+```python Python
+series, cursor = ex.fetch_series(category="Economics", include_volume=True)
+```
+
+```typescript TypeScript
+const { series } = await ex.fetchSeries({ category: "Economics" });
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+{
+  "series": [
+    {
+      "id": "KXSPX",
+      "title": "S&P 500 Daily",
+      "category": "Economics",
+      "frequency": "daily",
+      "tags": ["finance", "indices"],
+      "settlement_sources": [
+        { "name": "S&P Dow Jones", "url": "https://www.spglobal.com" }
+      ],
+      "fee_type": "quadratic",
+      "volume": 1234567.89,
+      "last_updated_ts": "2026-04-27T00:00:00Z"
+    }
+  ],
+  "cursor": null
+}
+```
+
+</ResponseExample>

--- a/docs/api/tags/fetch-market-tags.mdx
+++ b/docs/api/tags/fetch-market-tags.mdx
@@ -1,0 +1,64 @@
+---
+title: "fetch_market_tags"
+sidebarTitle: "Fetch market tags"
+openapi: GET /v1/tags/fetch_market_tags
+playground: simple
+description: "Get the tag set associated with a market."
+---
+
+Returns the tag/category metadata used for filtering and search.
+
+<Note>
+  **Kalshi:** doesn't expose per-market tags — instead returns the flattened
+  global category-keyed map. The `market_id` argument is ignored on Kalshi
+  (every input returns the same union).
+
+  **Polymarket:** returns the tags attached to the specific market via
+  `GET /markets/{id}/tags`.
+</Note>
+
+## Parameters
+
+<ParamField path="market_id" type="string" required>
+  Native market identifier — Kalshi ticker or Polymarket condition ID.
+</ParamField>
+
+## Returns
+
+<ResponseField name="tags" type="Tag[]">
+  <Expandable title="Tag">
+    <ResponseField name="id" type="string" />
+    <ResponseField name="name" type="string" />
+    <ResponseField name="slug" type="string?" />
+  </Expandable>
+</ResponseField>
+
+<RequestExample>
+
+```rust Rust
+let tags = ex.fetch_market_tags("KXBTC-25MAR14-T20000").await?;
+for t in &tags {
+    println!("{}", t.name);
+}
+```
+
+```python Python
+tags = ex.fetch_market_tags("KXBTC-25MAR14-T20000")
+```
+
+```typescript TypeScript
+const tags = await ex.fetchMarketTags("KXBTC-25MAR14-T20000");
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+[
+  { "id": "Politics", "name": "Politics", "slug": "politics" },
+  { "id": "US Elections", "name": "US Elections", "slug": "us-elections" }
+]
+```
+
+</ResponseExample>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,6 +29,26 @@
             ]
           },
           {
+            "group": "Events",
+            "pages": [
+              "api/events/fetch-events",
+              "api/events/fetch-event"
+            ]
+          },
+          {
+            "group": "Series",
+            "pages": [
+              "api/series/fetch-series",
+              "api/series/fetch-series-one"
+            ]
+          },
+          {
+            "group": "Tags",
+            "pages": [
+              "api/tags/fetch-market-tags"
+            ]
+          },
+          {
             "group": "Orderbook",
             "pages": [
               "api/orderbook/fetch-orderbook"

--- a/engine/exchanges/kalshi/src/exchange.rs
+++ b/engine/exchanges/kalshi/src/exchange.rs
@@ -6,11 +6,12 @@ use std::time::Instant;
 use tokio::sync::Mutex;
 
 use px_core::{
-    canonical_event_id, manifests::KALSHI_MANIFEST, sort_asks, sort_bids, Candlestick, Exchange,
-    ExchangeInfo, ExchangeManifest, FetchMarketsParams, FetchOrdersParams, Fill, Market,
-    MarketStatus, MarketStatusFilter, MarketTrade, MarketType, OpenPxError, Order, OrderSide,
-    OrderStatus, Orderbook, OutcomeToken, Position, PriceHistoryInterval, PriceHistoryRequest,
-    PriceLevel, RateLimiter, TradesRequest,
+    canonical_event_id, manifests::KALSHI_MANIFEST, sort_asks, sort_bids, Candlestick, Event,
+    EventsRequest, Exchange, ExchangeInfo, ExchangeManifest, FetchMarketsParams, FetchOrdersParams,
+    Fill, Market, MarketStatus, MarketStatusFilter, MarketTrade, MarketType, OpenPxError, Order,
+    OrderSide, OrderStatus, Orderbook, OutcomeToken, Position, PriceHistoryInterval,
+    PriceHistoryRequest, PriceLevel, RateLimiter, Series, SeriesRequest, SettlementSource, Tag,
+    TradesRequest,
 };
 
 use crate::auth::KalshiAuth;
@@ -58,6 +59,147 @@ fn parse_numeric_value(val: &Option<serde_json::Value>) -> Option<f64> {
 
 pub(crate) fn to_openpx(e: KalshiError) -> OpenPxError {
     OpenPxError::Exchange(e.into())
+}
+
+fn parse_iso_datetime(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+}
+
+fn parse_kalshi_event(value: &serde_json::Value) -> Option<Event> {
+    let obj = value.as_object()?;
+    let id = obj.get("event_ticker").and_then(|v| v.as_str())?.to_string();
+
+    let title = obj
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let description = obj
+        .get("sub_title")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    let series_id = obj
+        .get("series_ticker")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let mutually_exclusive = obj.get("mutually_exclusive").and_then(|v| v.as_bool());
+
+    // Strike date doubles as the resolution / end timestamp.
+    let end_ts = obj
+        .get("strike_date")
+        .and_then(|v| v.as_str())
+        .and_then(parse_iso_datetime);
+
+    let last_updated_ts = obj
+        .get("last_updated_ts")
+        .and_then(|v| v.as_str())
+        .and_then(parse_iso_datetime);
+
+    let market_ids = obj
+        .get("markets")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    m.get("ticker")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Some(Event {
+        id,
+        slug: None,
+        title,
+        description,
+        category: None,
+        series_id,
+        status: None,
+        market_ids,
+        start_ts: None,
+        end_ts,
+        volume: None,
+        open_interest: None,
+        mutually_exclusive,
+        last_updated_ts,
+    })
+}
+
+fn parse_kalshi_series(value: &serde_json::Value) -> Option<Series> {
+    let obj = value.as_object()?;
+    let id = obj.get("ticker").and_then(|v| v.as_str())?.to_string();
+
+    let title = obj
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let category = obj
+        .get("category")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let frequency = obj
+        .get("frequency")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let tags = obj
+        .get("tags")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let settlement_sources = obj
+        .get("settlement_sources")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|s| SettlementSource {
+                    name: s.get("name").and_then(|v| v.as_str()).map(String::from),
+                    url: s.get("url").and_then(|v| v.as_str()).map(String::from),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let fee_type = obj
+        .get("fee_type")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    // `volume_fp` arrives as a fixed-point string when include_volume=true.
+    let volume = parse_fp(obj, "volume_fp");
+
+    let last_updated_ts = obj
+        .get("last_updated_ts")
+        .and_then(|v| v.as_str())
+        .and_then(parse_iso_datetime);
+
+    Some(Series {
+        id,
+        title,
+        category,
+        frequency,
+        tags,
+        settlement_sources,
+        fee_type,
+        volume,
+        last_updated_ts,
+    })
 }
 
 pub struct Kalshi {
@@ -1430,6 +1572,156 @@ impl Exchange for Kalshi {
         Ok((trades, next_cursor))
     }
 
+    async fn fetch_events(
+        &self,
+        req: EventsRequest,
+    ) -> Result<(Vec<Event>, Option<String>), OpenPxError> {
+        #[derive(Debug, serde::Deserialize)]
+        struct EventsResp {
+            #[serde(default)]
+            events: Vec<serde_json::Value>,
+            cursor: Option<String>,
+        }
+
+        let limit = req.limit.unwrap_or(200).clamp(1, 200);
+        let mut path = format!("/events?limit={limit}");
+        if let Some(c) = req.cursor.as_deref().filter(|c| !c.is_empty()) {
+            path.push_str(&format!("&cursor={c}"));
+        }
+        if let Some(s) = req.status.as_deref() {
+            path.push_str(&format!("&status={s}"));
+        }
+        if let Some(s) = req.series_id.as_deref() {
+            path.push_str(&format!("&series_ticker={s}"));
+        }
+        if req.with_nested_markets.unwrap_or(false) {
+            path.push_str("&with_nested_markets=true");
+        }
+        if let Some(ts) = req.min_close_ts {
+            path.push_str(&format!("&min_close_ts={ts}"));
+        }
+        if let Some(ts) = req.min_updated_ts {
+            path.push_str(&format!("&min_updated_ts={ts}"));
+        }
+
+        let resp: EventsResp = self.get(&path).await.map_err(to_openpx)?;
+        let next_cursor = resp.cursor.filter(|c| !c.is_empty());
+        let events = resp
+            .events
+            .iter()
+            .filter_map(parse_kalshi_event)
+            .collect();
+        Ok((events, next_cursor))
+    }
+
+    async fn fetch_event(&self, id: &str) -> Result<Event, OpenPxError> {
+        #[derive(Debug, serde::Deserialize)]
+        struct EventResp {
+            event: serde_json::Value,
+            #[serde(default)]
+            markets: Option<Vec<serde_json::Value>>,
+        }
+
+        let path = format!("/events/{id}?with_nested_markets=true");
+        let resp: EventResp = self.get(&path).await.map_err(to_openpx)?;
+
+        let mut event = parse_kalshi_event(&resp.event).ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::Api(format!(
+                "could not parse event: {id}"
+            )))
+        })?;
+
+        // Top-level `markets` is sibling of `event` when `with_nested_markets=false`
+        // — fold it in if present and the event itself didn't carry it.
+        if event.market_ids.is_empty() {
+            if let Some(markets) = resp.markets {
+                event.market_ids = markets
+                    .iter()
+                    .filter_map(|m| {
+                        m.get("ticker")
+                            .and_then(|v| v.as_str())
+                            .map(String::from)
+                    })
+                    .collect();
+            }
+        }
+
+        Ok(event)
+    }
+
+    async fn fetch_series(
+        &self,
+        req: SeriesRequest,
+    ) -> Result<(Vec<Series>, Option<String>), OpenPxError> {
+        #[derive(Debug, serde::Deserialize)]
+        struct SeriesResp {
+            #[serde(default)]
+            series: Vec<serde_json::Value>,
+            cursor: Option<String>,
+        }
+
+        let limit = req.limit.unwrap_or(100).clamp(1, 200);
+        let mut path = format!("/series?limit={limit}");
+        if let Some(c) = req.cursor.as_deref().filter(|c| !c.is_empty()) {
+            path.push_str(&format!("&cursor={c}"));
+        }
+        if let Some(c) = req.category.as_deref() {
+            path.push_str(&format!("&category={c}"));
+        }
+        if req.include_volume.unwrap_or(false) {
+            path.push_str("&include_volume=true");
+        }
+
+        let resp: SeriesResp = self.get(&path).await.map_err(to_openpx)?;
+        let next_cursor = resp.cursor.filter(|c| !c.is_empty());
+        let series = resp.series.iter().filter_map(parse_kalshi_series).collect();
+        Ok((series, next_cursor))
+    }
+
+    async fn fetch_series_one(&self, id: &str) -> Result<Series, OpenPxError> {
+        #[derive(Debug, serde::Deserialize)]
+        struct SeriesResp {
+            series: serde_json::Value,
+        }
+
+        let path = format!("/series/{id}?include_volume=true");
+        let resp: SeriesResp = self.get(&path).await.map_err(to_openpx)?;
+        parse_kalshi_series(&resp.series).ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::Api(format!(
+                "could not parse series: {id}"
+            )))
+        })
+    }
+
+    async fn fetch_market_tags(&self, _market_id: &str) -> Result<Vec<Tag>, OpenPxError> {
+        // Kalshi doesn't expose per-market tags; it groups tags by category at
+        // the global level. Return the flattened union — same content for any
+        // market_id input.
+        #[derive(Debug, serde::Deserialize)]
+        struct TagsResp {
+            #[serde(default)]
+            tags_by_categories: HashMap<String, Vec<String>>,
+        }
+
+        let resp: TagsResp = self
+            .get("/search/tags_by_categories")
+            .await
+            .map_err(to_openpx)?;
+
+        let tags = resp
+            .tags_by_categories
+            .into_iter()
+            .flat_map(|(_category, names)| {
+                names.into_iter().map(|name| Tag {
+                    id: name.clone(),
+                    slug: Some(name.to_ascii_lowercase().replace(' ', "-")),
+                    name,
+                })
+            })
+            .collect();
+        Ok(tags)
+    }
+
     async fn create_order(
         &self,
         market_id: &str,
@@ -1684,21 +1976,100 @@ impl Exchange for Kalshi {
             has_refresh_balance: false,
             has_websocket: self.auth.is_some() && !self.config.demo,
             has_fetch_orderbook_history: false,
-            has_fetch_events: false,
-            has_fetch_event: false,
+            has_fetch_events: true,
+            has_fetch_event: true,
             has_fetch_orderbooks_batch: false,
-            has_fetch_series: false,
-            has_fetch_series_one: false,
+            has_fetch_series: true,
+            has_fetch_series_one: true,
             has_fetch_midpoint: false,
             has_fetch_midpoints_batch: false,
             has_fetch_spread: false,
             has_fetch_last_trade_price: false,
             has_fetch_open_interest: false,
             has_fetch_user_trades: false,
-            has_fetch_market_tags: false,
+            has_fetch_market_tags: true,
             has_cancel_all_orders: false,
             has_create_orders_batch: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod parse_event_series_tests {
+    use super::{parse_kalshi_event, parse_kalshi_series};
+
+    #[test]
+    fn parse_kalshi_event_minimal_payload() {
+        let v = serde_json::json!({
+            "event_ticker": "KXPRES-2028",
+            "series_ticker": "KXPRES",
+            "title": "2028 US Presidential Election",
+            "sub_title": "Winning candidate",
+            "mutually_exclusive": true,
+            "strike_date": "2028-11-07T00:00:00Z",
+            "last_updated_ts": "2026-04-26T12:34:56Z",
+        });
+        let e = parse_kalshi_event(&v).expect("should parse");
+        assert_eq!(e.id, "KXPRES-2028");
+        assert_eq!(e.series_id.as_deref(), Some("KXPRES"));
+        assert_eq!(e.title, "2028 US Presidential Election");
+        assert_eq!(e.description.as_deref(), Some("Winning candidate"));
+        assert_eq!(e.mutually_exclusive, Some(true));
+        assert!(e.end_ts.is_some());
+        assert!(e.last_updated_ts.is_some());
+        assert!(e.market_ids.is_empty());
+    }
+
+    #[test]
+    fn parse_kalshi_event_with_nested_markets() {
+        let v = serde_json::json!({
+            "event_ticker": "EVT",
+            "title": "T",
+            "markets": [
+                { "ticker": "M-A" },
+                { "ticker": "M-B" },
+                { "no_ticker_here": "skip" },
+            ],
+        });
+        let e = parse_kalshi_event(&v).expect("parse");
+        assert_eq!(e.market_ids, vec!["M-A".to_string(), "M-B".to_string()]);
+    }
+
+    #[test]
+    fn parse_kalshi_event_missing_required_returns_none() {
+        let v = serde_json::json!({ "title": "no ticker" });
+        assert!(parse_kalshi_event(&v).is_none());
+    }
+
+    #[test]
+    fn parse_kalshi_series_with_volume() {
+        let v = serde_json::json!({
+            "ticker": "KXSPX",
+            "title": "S&P 500 Daily",
+            "category": "Economics",
+            "frequency": "daily",
+            "tags": ["finance", "indices"],
+            "settlement_sources": [
+                { "name": "S&P Dow Jones", "url": "https://example.com" },
+            ],
+            "fee_type": "quadratic",
+            "volume_fp": "1234567.89",
+            "last_updated_ts": "2026-04-27T00:00:00Z",
+        });
+        let s = parse_kalshi_series(&v).expect("parse");
+        assert_eq!(s.id, "KXSPX");
+        assert_eq!(s.frequency.as_deref(), Some("daily"));
+        assert_eq!(s.tags, vec!["finance".to_string(), "indices".to_string()]);
+        assert_eq!(s.settlement_sources.len(), 1);
+        assert_eq!(s.fee_type.as_deref(), Some("quadratic"));
+        assert_eq!(s.volume, Some(1_234_567.89));
+    }
+
+    #[test]
+    fn parse_kalshi_series_without_volume_omits_field() {
+        let v = serde_json::json!({ "ticker": "KX", "title": "x" });
+        let s = parse_kalshi_series(&v).expect("parse");
+        assert!(s.volume.is_none());
     }
 }
 

--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -18,12 +18,13 @@ use tokio::sync::{Mutex, RwLock};
 use tracing::info;
 
 use px_core::{
-    canonical_event_id, manifests::POLYMARKET_MANIFEST, sort_asks, sort_bids, Candlestick,
-    Exchange, ExchangeInfo, ExchangeManifest, FetchMarketsParams, FetchOrdersParams,
-    FetchUserActivityParams, Fill, Market, MarketStatus, MarketStatusFilter, MarketTrade,
-    MarketType, OpenPxError, Order, OrderSide, OrderStatus, Orderbook, OrderbookHistoryRequest,
-    OrderbookSnapshot, OutcomeToken, Position, PriceHistoryInterval, PriceHistoryRequest,
-    PriceLevel, PublicTrade, RateLimiter, TradesRequest,
+    canonical_event_id, manifests::POLYMARKET_MANIFEST, sort_asks, sort_bids, Candlestick, Event,
+    EventsRequest, Exchange, ExchangeInfo, ExchangeManifest, FetchMarketsParams,
+    FetchOrdersParams, FetchUserActivityParams, Fill, Market, MarketStatus, MarketStatusFilter,
+    MarketTrade, MarketType, OpenPxError, Order, OrderSide, OrderStatus, Orderbook,
+    OrderbookHistoryRequest, OrderbookSnapshot, OutcomeToken, Position, PriceHistoryInterval,
+    PriceHistoryRequest, PriceLevel, PublicTrade, RateLimiter, Series, SeriesRequest,
+    SettlementSource, Tag, TradesRequest,
 };
 
 use crate::approvals::{AllowanceStatus, ApprovalRequest, ApprovalResponse, TokenApprover};
@@ -2989,6 +2990,176 @@ impl Exchange for Polymarket {
         }))
     }
 
+    async fn fetch_events(
+        &self,
+        req: EventsRequest,
+    ) -> Result<(Vec<Event>, Option<String>), OpenPxError> {
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(untagged)]
+        enum EventsResp {
+            Wrapped {
+                #[serde(default)]
+                events: Vec<serde_json::Value>,
+                #[serde(default)]
+                next_cursor: Option<String>,
+            },
+            Bare(Vec<serde_json::Value>),
+        }
+
+        let limit = req.limit.unwrap_or(20).clamp(1, 500);
+        let mut endpoint = format!("/events/keyset?limit={limit}");
+        if let Some(c) = req.cursor.as_deref().filter(|c| !c.is_empty()) {
+            endpoint.push_str(&format!("&after_cursor={c}"));
+        }
+        if let Some(s) = req.status.as_deref() {
+            // Polymarket uses `closed=true|false` rather than a free-form status.
+            match s {
+                "closed" => endpoint.push_str("&closed=true"),
+                "open" => endpoint.push_str("&closed=false"),
+                other => endpoint.push_str(&format!("&{other}")),
+            }
+        }
+        if let Some(s) = req.series_id.as_deref() {
+            endpoint.push_str(&format!("&series_id={s}"));
+        }
+        if let Some(ts) = req.min_close_ts {
+            endpoint.push_str(&format!("&end_date_min={ts}"));
+        }
+
+        let resp: EventsResp = self
+            .client
+            .get_gamma(&endpoint)
+            .await
+            .map_err(|e| OpenPxError::Exchange(e.into()))?;
+        let (raw, next_cursor) = match resp {
+            EventsResp::Wrapped { events, next_cursor } => {
+                (events, next_cursor.filter(|c| !c.is_empty()))
+            }
+            EventsResp::Bare(events) => (events, None),
+        };
+        let events = raw.iter().filter_map(parse_polymarket_event).collect();
+        Ok((events, next_cursor))
+    }
+
+    async fn fetch_event(&self, id: &str) -> Result<Event, OpenPxError> {
+        // Polymarket accepts both UUID-shaped IDs and slugs. UUID-like input
+        // hits `/events/{id}`; everything else falls back to `/events/slug/{slug}`.
+        let endpoint = if id.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
+            && id.len() >= 32
+        {
+            format!("/events/{id}")
+        } else {
+            format!("/events/slug/{id}")
+        };
+
+        let value: serde_json::Value = self
+            .client
+            .get_gamma(&endpoint)
+            .await
+            .map_err(|e| OpenPxError::Exchange(e.into()))?;
+
+        parse_polymarket_event(&value).ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::Api(format!(
+                "could not parse event: {id}"
+            )))
+        })
+    }
+
+    async fn fetch_series(
+        &self,
+        req: SeriesRequest,
+    ) -> Result<(Vec<Series>, Option<String>), OpenPxError> {
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(untagged)]
+        enum SeriesResp {
+            Wrapped {
+                #[serde(default)]
+                series: Vec<serde_json::Value>,
+                #[serde(default)]
+                next_cursor: Option<String>,
+            },
+            Bare(Vec<serde_json::Value>),
+        }
+
+        let limit = req.limit.unwrap_or(20).clamp(1, 500);
+        let mut endpoint = format!("/series?limit={limit}");
+        if let Some(c) = req.cursor.as_deref().filter(|c| !c.is_empty()) {
+            endpoint.push_str(&format!("&after_cursor={c}"));
+        }
+        if let Some(c) = req.category.as_deref() {
+            endpoint.push_str(&format!("&category={c}"));
+        }
+
+        let resp: SeriesResp = self
+            .client
+            .get_gamma(&endpoint)
+            .await
+            .map_err(|e| OpenPxError::Exchange(e.into()))?;
+        let (raw, next_cursor) = match resp {
+            SeriesResp::Wrapped { series, next_cursor } => {
+                (series, next_cursor.filter(|c| !c.is_empty()))
+            }
+            SeriesResp::Bare(series) => (series, None),
+        };
+        let series = raw.iter().filter_map(parse_polymarket_series).collect();
+        Ok((series, next_cursor))
+    }
+
+    async fn fetch_series_one(&self, id: &str) -> Result<Series, OpenPxError> {
+        let endpoint = format!("/series/{id}");
+        let value: serde_json::Value = self
+            .client
+            .get_gamma(&endpoint)
+            .await
+            .map_err(|e| OpenPxError::Exchange(e.into()))?;
+
+        parse_polymarket_series(&value).ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::Api(format!(
+                "could not parse series: {id}"
+            )))
+        })
+    }
+
+    async fn fetch_market_tags(&self, market_id: &str) -> Result<Vec<Tag>, OpenPxError> {
+        #[derive(Debug, serde::Deserialize)]
+        #[serde(untagged)]
+        enum TagsResp {
+            Wrapped {
+                #[serde(default)]
+                tags: Vec<serde_json::Value>,
+            },
+            Bare(Vec<serde_json::Value>),
+        }
+
+        let endpoint = format!("/markets/{market_id}/tags");
+        let resp: TagsResp = self
+            .client
+            .get_gamma(&endpoint)
+            .await
+            .map_err(|e| OpenPxError::Exchange(e.into()))?;
+        let raw = match resp {
+            TagsResp::Wrapped { tags } => tags,
+            TagsResp::Bare(tags) => tags,
+        };
+
+        let tags = raw
+            .iter()
+            .filter_map(|t| {
+                let obj = t.as_object()?;
+                let id = obj
+                    .get("id")
+                    .and_then(|v| v.as_str().map(String::from).or_else(|| v.as_i64().map(|i| i.to_string())))?;
+                let name = obj.get("label").or_else(|| obj.get("name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let slug = obj.get("slug").and_then(|v| v.as_str()).map(String::from);
+                Some(Tag { id, name, slug })
+            })
+            .collect();
+        Ok(tags)
+    }
+
     fn describe(&self) -> ExchangeInfo {
         let authed = self.config.is_authenticated();
         ExchangeInfo {
@@ -3013,22 +3184,171 @@ impl Exchange for Polymarket {
             // Flag is false because historical data is now served from S3 Parquet
             // (backfilled via historical data pipeline), not proxied through CLOB.
             has_fetch_orderbook_history: false,
-            has_fetch_events: false,
-            has_fetch_event: false,
+            has_fetch_events: true,
+            has_fetch_event: true,
             has_fetch_orderbooks_batch: false,
-            has_fetch_series: false,
-            has_fetch_series_one: false,
+            has_fetch_series: true,
+            has_fetch_series_one: true,
             has_fetch_midpoint: false,
             has_fetch_midpoints_batch: false,
             has_fetch_spread: false,
             has_fetch_last_trade_price: false,
             has_fetch_open_interest: false,
             has_fetch_user_trades: false,
-            has_fetch_market_tags: false,
+            has_fetch_market_tags: true,
             has_cancel_all_orders: false,
             has_create_orders_batch: false,
         }
     }
+}
+
+fn parse_polymarket_event(value: &serde_json::Value) -> Option<Event> {
+    let obj = value.as_object()?;
+
+    let id = obj
+        .get("id")
+        .and_then(|v| {
+            v.as_str()
+                .map(String::from)
+                .or_else(|| v.as_i64().map(|i| i.to_string()))
+                .or_else(|| v.as_u64().map(|u| u.to_string()))
+        })?;
+
+    let slug = obj.get("slug").and_then(|v| v.as_str()).map(String::from);
+    let title = obj
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let description = obj
+        .get("description")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+    let category = obj
+        .get("category")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let series_id = obj
+        .get("series")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|s| s.get("id"))
+        .and_then(|v| {
+            v.as_str()
+                .map(String::from)
+                .or_else(|| v.as_i64().map(|i| i.to_string()))
+        });
+
+    let parse_dt = |key: &str| -> Option<chrono::DateTime<chrono::Utc>> {
+        obj.get(key)
+            .and_then(|v| v.as_str())
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+    };
+    let parse_f64 = |key: &str| -> Option<f64> {
+        obj.get(key).and_then(|v| {
+            v.as_f64()
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        })
+    };
+
+    let start_ts = parse_dt("startDate");
+    let end_ts = parse_dt("endDate");
+    let last_updated_ts = parse_dt("updatedAt");
+    let volume = parse_f64("volume");
+    let open_interest = parse_f64("openInterest");
+
+    let mutually_exclusive = obj
+        .get("negRisk")
+        .or_else(|| obj.get("mutuallyExclusive"))
+        .and_then(|v| v.as_bool());
+
+    let market_ids = obj
+        .get("markets")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|m| {
+                    m.get("id")
+                        .or_else(|| m.get("conditionId"))
+                        .and_then(|v| v.as_str().map(String::from))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let status = obj
+        .get("closed")
+        .and_then(|v| v.as_bool())
+        .map(|c| if c { "closed" } else { "open" }.to_string());
+
+    Some(Event {
+        id,
+        slug,
+        title,
+        description,
+        category,
+        series_id,
+        status,
+        market_ids,
+        start_ts,
+        end_ts,
+        volume,
+        open_interest,
+        mutually_exclusive,
+        last_updated_ts,
+    })
+}
+
+fn parse_polymarket_series(value: &serde_json::Value) -> Option<Series> {
+    let obj = value.as_object()?;
+
+    let id = obj.get("id").and_then(|v| {
+        v.as_str()
+            .map(String::from)
+            .or_else(|| v.as_i64().map(|i| i.to_string()))
+            .or_else(|| v.as_u64().map(|u| u.to_string()))
+    })?;
+
+    let title = obj
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let category = obj
+        .get("category")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let frequency = obj
+        .get("frequency")
+        .or_else(|| obj.get("recurrence"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let last_updated_ts = obj
+        .get("updatedAt")
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.with_timezone(&chrono::Utc));
+
+    let volume = obj.get("volume").and_then(|v| {
+        v.as_f64()
+            .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+    });
+
+    Some(Series {
+        id,
+        title,
+        category,
+        frequency,
+        tags: Vec::new(),
+        settlement_sources: Vec::<SettlementSource>::new(),
+        fee_type: None,
+        volume,
+        last_updated_ts,
+    })
 }
 
 #[cfg(test)]
@@ -3081,6 +3401,78 @@ mod tests {
         let mut params = HashMap::new();
         params.insert("order_type".to_string(), "market".to_string());
         assert!(polymarket_order_type(&params).is_err());
+    }
+
+    // --- Event / Series parser tests (Batch 2) ---
+
+    use super::{parse_polymarket_event, parse_polymarket_series};
+
+    #[test]
+    fn parse_polymarket_event_full_payload() {
+        let v = serde_json::json!({
+            "id": "abc-123",
+            "slug": "us-2028-election",
+            "title": "2028 US Election",
+            "description": "Who wins?",
+            "category": "Politics",
+            "startDate": "2028-01-01T00:00:00Z",
+            "endDate": "2028-11-07T00:00:00Z",
+            "updatedAt": "2026-04-27T12:00:00Z",
+            "volume": 1234567.5,
+            "openInterest": "50000",
+            "negRisk": true,
+            "closed": false,
+            "markets": [
+                { "id": "0xMARKET1", "conditionId": "0xCID1" },
+                { "conditionId": "0xCID2" },
+            ],
+            "series": [{ "id": "ser-99" }],
+        });
+        let e = parse_polymarket_event(&v).expect("parse");
+        assert_eq!(e.id, "abc-123");
+        assert_eq!(e.slug.as_deref(), Some("us-2028-election"));
+        assert_eq!(e.category.as_deref(), Some("Politics"));
+        assert_eq!(e.series_id.as_deref(), Some("ser-99"));
+        assert_eq!(e.status.as_deref(), Some("open"));
+        assert_eq!(e.volume, Some(1_234_567.5));
+        assert_eq!(e.open_interest, Some(50_000.0));
+        assert_eq!(e.mutually_exclusive, Some(true));
+        assert_eq!(e.market_ids, vec!["0xMARKET1".to_string(), "0xCID2".to_string()]);
+        assert!(e.start_ts.is_some());
+        assert!(e.end_ts.is_some());
+    }
+
+    #[test]
+    fn parse_polymarket_event_numeric_id_coerces_to_string() {
+        let v = serde_json::json!({ "id": 42, "title": "n" });
+        let e = parse_polymarket_event(&v).expect("parse");
+        assert_eq!(e.id, "42");
+    }
+
+    #[test]
+    fn parse_polymarket_event_closed_event_yields_closed_status() {
+        let v = serde_json::json!({ "id": "x", "title": "t", "closed": true });
+        let e = parse_polymarket_event(&v).expect("parse");
+        assert_eq!(e.status.as_deref(), Some("closed"));
+    }
+
+    #[test]
+    fn parse_polymarket_series_minimal() {
+        let v = serde_json::json!({
+            "id": 7,
+            "title": "Weekly NFP",
+            "category": "Economics",
+            "recurrence": "weekly",
+            "updatedAt": "2026-04-27T00:00:00Z",
+            "volume": "98765.43",
+        });
+        let s = parse_polymarket_series(&v).expect("parse");
+        assert_eq!(s.id, "7");
+        assert_eq!(s.title, "Weekly NFP");
+        assert_eq!(s.category.as_deref(), Some("Economics"));
+        assert_eq!(s.frequency.as_deref(), Some("weekly"));
+        assert_eq!(s.volume, Some(98_765.43));
+        assert!(s.last_updated_ts.is_some());
     }
 
     // --- Reconstructed OHLCV tests ---

--- a/maintenance/manifest-allowlists/kalshi.txt
+++ b/maintenance/manifest-allowlists/kalshi.txt
@@ -56,3 +56,21 @@ message                 # error.message
 # --- Status field name (specific values "active"/"unopened"/etc are in status_map) ---
 status                  # status field; values are matched via map_status
 accepting_orders        # Boolean flag complementary to status; not part of map_status enum
+
+# --- Event / Series / Tags parsing (new in Batch 2; Event, Series, Tag models, not Market) ---
+event_ticker            # Event.id (Kalshi event identifier)
+series_ticker           # Event.series_id / Series root identifier
+sub_title               # Event.description fallback (Kalshi `sub_title` is event subtitle)
+mutually_exclusive      # Event.mutually_exclusive flag
+strike_date             # Event.end_ts (resolution date)
+last_updated_ts         # Event/Series last_updated_ts (ISO 8601)
+markets                 # Nested markets array on event payload (when with_nested_markets=true)
+frequency               # Series.frequency (e.g. "weekly", "monthly")
+tags                    # Series.tags (Vec<String>) — distinct from market_tags result
+settlement_sources      # Series.settlement_sources (Vec<{name, url}>)
+name                    # SettlementSource.name field
+url                     # SettlementSource.url field
+fee_type                # Series.fee_type (e.g. "quadratic")
+category                # Series.category — used to filter SeriesRequest, not Market.category
+tags_by_categories      # Tags-by-category response wrapper (/search/tags_by_categories)
+/search/tags_by_categories  # URL path passed to self.get() — not a JSON key, test is over-broad

--- a/maintenance/manifest-allowlists/polymarket.txt
+++ b/maintenance/manifest-allowlists/polymarket.txt
@@ -54,3 +54,12 @@ active                  # Boolean active flag
 
 # --- Internal data envelope wrappers ---
 data                    # Generic data envelope used by some Polymarket endpoints
+
+# --- Event / Series / Tags parsing (new in Batch 2; Gamma API; Event, Series, Tag models) ---
+category                # Event.category / Series.category (free-form string)
+series                  # Gamma event payload's nested series array; pick first as Event.series_id
+mutuallyExclusive       # Camel-case alias for negRisk (Event.mutually_exclusive)
+updatedAt               # Event/Series last_updated_ts (ISO 8601)
+recurrence              # Series.frequency alias on Gamma (some payloads use `recurrence`)
+frequency               # Series.frequency
+label                   # Tag.name on per-market tag objects (Gamma)


### PR DESCRIPTION
## Summary

Stacked on **#56** (chore/unified-api-14-methods). Implements 5 metadata methods on both Kalshi and Polymarket — \`fetch_events\`, \`fetch_event\`, \`fetch_series\`, \`fetch_series_one\`, \`fetch_market_tags\`. Flips the corresponding \`has_*\` flags on each \`describe()\` from \`false\` to \`true\`.

## Methods implemented (10 impls — 5 methods × 2 venues)

### Kalshi (\`engine/exchanges/kalshi/src/exchange.rs\`)
| Method | Endpoint | Notes |
|---|---|---|
| \`fetch_events\` | \`GET /events?limit&cursor&status&series_ticker&with_nested_markets&min_close_ts&min_updated_ts\` | Cursor-paginated; default 200, max 200 |
| \`fetch_event\` | \`GET /events/{event_ticker}?with_nested_markets=true\` | Falls back to top-level \`markets\` field if event payload doesn't carry nested IDs |
| \`fetch_series\` | \`GET /series?limit&cursor&category&include_volume\` | Cursor-paginated; default 100, max 200 |
| \`fetch_series_one\` | \`GET /series/{series_ticker}?include_volume=true\` | Reads \`volume_fp\` fixed-point string |
| \`fetch_market_tags\` | \`GET /search/tags_by_categories\` | Kalshi exposes only a global category-keyed map; flattened into \`Vec<Tag>\` with auto-derived slugs. \`market_id\` arg intentionally ignored — same return for any input |

### Polymarket (\`engine/exchanges/polymarket/src/exchange.rs\`)
Gamma API (\`gamma-api.polymarket.com\`) — **keyset pagination via \`after_cursor\`, NOT offset**.

| Method | Endpoint | Notes |
|---|---|---|
| \`fetch_events\` | \`GET /events/keyset?limit&after_cursor&closed=...\` | Maps \`req.status\` → \`closed=true|false\`. \`untagged\` enum handles both wrapped and bare-array responses |
| \`fetch_event\` | \`GET /events/{id}\` or \`GET /events/slug/{slug}\` | UUID heuristic dispatches: hex-and-dash + ≥32 chars → \`/events/{id}\`; else slug |
| \`fetch_series\` | \`GET /series?limit&after_cursor&category\` | |
| \`fetch_series_one\` | \`GET /series/{id}\` | |
| \`fetch_market_tags\` | \`GET /markets/{id}/tags\` | Tags carry \`id\`, \`label\` (or \`name\`), \`slug\` |

## Parser helpers

Two pure parsers per venue (file-private, isolated for unit testability):
- \`parse_kalshi_event\`, \`parse_kalshi_series\`
- \`parse_polymarket_event\`, \`parse_polymarket_series\`

All handle missing/null/numeric-id fields defensively. Polymarket's \`id\` may arrive as either a string or integer in different Gamma endpoints — both coerced to \`String\`.

## Manifest allowlists

\`maintenance/manifest-allowlists/{kalshi,polymarket}.txt\` extended with the new JSON keys read by the parsers (16 Kalshi, 7 Polymarket) so \`manifest_coverage\` continues to guard the unified-schema contract mechanically.

## Test plan

- [x] 5 new Kalshi parser tests (\`parse_event_series_tests\` module)
- [x] 4 new Polymarket parser tests (in existing \`tests\` module)
- [x] \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p px-core --test manifest_coverage\` green
- [x] \`just check-sync\` clean — no schema regen needed (trait + types live in #56)
- [ ] Live test against real Kalshi + Polymarket Gamma — gated on credentials; reviewer to spot-check on pre-merge

## Stack

- Base: **#56** (chore/unified-api-14-methods)
- Independent of the V2 migration stack (#54, #55)
- Future: Batches 3, 4, 5 each open as separate PRs against #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)