### PR TITLE
feat(exchanges): implement pricing/books methods on both venues (Batch 3)

### DIFF
--- a/docs/api/orderbook/fetch-orderbooks-batch.mdx
+++ b/docs/api/orderbook/fetch-orderbooks-batch.mdx
@@ -1,0 +1,86 @@
+---
+title: "fetch_orderbooks_batch"
+sidebarTitle: "Fetch orderbooks (batch)"
+openapi: GET /v1/orderbook/fetch_orderbooks_batch
+playground: simple
+description: "Fetch L2 orderbooks for multiple markets in a single round-trip."
+---
+
+Major HFT/MM latency win — replaces N parallel calls to
+[`fetch_orderbook`](/api/orderbook/fetch-orderbook) with a single batched request.
+
+## Parameters
+
+<ParamField path="market_ids" type="string[]" required>
+  Identifiers for the books to fetch. **Kalshi:** market tickers (max 100).
+  **Polymarket:** CLOB token IDs.
+</ParamField>
+
+## Returns
+
+<ResponseField name="orderbooks" type="Orderbook[]">
+  One `Orderbook` per input. Order matches the input order on Polymarket;
+  Kalshi may return in arbitrary order — match by `market_id`.
+
+  <Expandable title="Orderbook">
+    <ResponseField name="market_id" type="string" />
+    <ResponseField name="asset_id" type="string">Polymarket token id; Kalshi ticker.</ResponseField>
+    <ResponseField name="bids" type="PriceLevel[]">Sorted descending.</ResponseField>
+    <ResponseField name="asks" type="PriceLevel[]">Sorted ascending.</ResponseField>
+    <ResponseField name="last_update_id" type="u64?" />
+    <ResponseField name="timestamp" type="DateTime?" />
+    <ResponseField name="hash" type="string?">Polymarket book-state integrity hash.</ResponseField>
+  </Expandable>
+</ResponseField>
+
+<Note>
+  **Kalshi** binary markets expose a YES half-orderbook plus a NO half. OpenPX
+  unifies these: YES levels become `bids`; NO bids at price X become `asks`
+  at price `1 - X`. The result is a single book centered on the YES outcome.
+</Note>
+
+<RequestExample>
+
+```rust Rust
+let books = ex
+    .fetch_orderbooks_batch(vec![
+        "KXBTC-25MAR14-T20000".into(),
+        "KXBTC-25MAR14-T25000".into(),
+    ])
+    .await?;
+for b in &books {
+    println!("{}: bid {:?} / ask {:?}", b.market_id, b.best_bid(), b.best_ask());
+}
+```
+
+```python Python
+books = ex.fetch_orderbooks_batch([
+    "KXBTC-25MAR14-T20000",
+    "KXBTC-25MAR14-T25000",
+])
+```
+
+```typescript TypeScript
+const books = await ex.fetchOrderbooksBatch([
+  "KXBTC-25MAR14-T20000",
+  "KXBTC-25MAR14-T25000",
+]);
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+[
+  {
+    "market_id": "KXBTC-25MAR14-T20000",
+    "asset_id": "KXBTC-25MAR14-T20000",
+    "bids": [{ "price": 0.42, "size": 100.0 }, { "price": 0.41, "size": 50.0 }],
+    "asks": [{ "price": 0.46, "size": 80.0 }, { "price": 0.47, "size": 200.0 }],
+    "timestamp": "2026-04-28T10:15:30Z"
+  }
+]
+```
+
+</ResponseExample>

--- a/docs/api/pricing/fetch-last-trade-price.mdx
+++ b/docs/api/pricing/fetch-last-trade-price.mdx
@@ -1,0 +1,63 @@
+---
+title: "fetch_last_trade_price"
+sidebarTitle: "Fetch last trade price"
+openapi: GET /v1/pricing/fetch_last_trade_price
+playground: simple
+description: "Get the most recent public trade for a market outcome."
+---
+
+Single-print summary — what just executed. Cheaper than fetching the full
+[`fetch_trades`](/api/trades/fetch-trades) tape.
+
+## Parameters
+
+Same shape as [`fetch_midpoint`](/api/pricing/fetch-midpoint) — uses the
+unified `MidpointRequest` type.
+
+<ParamField path="market_id" type="string" required />
+<ParamField path="outcome" type="string?" />
+<ParamField path="token_id" type="string?" />
+
+## Returns
+
+<ResponseField name="LastTrade" type="object">
+  <ResponseField name="price" type="f64" />
+  <ResponseField name="side" type="OrderSide">`buy` or `sell`.</ResponseField>
+  <ResponseField name="size" type="f64" />
+  <ResponseField name="ts_ms" type="i64">Trade timestamp (Unix milliseconds).</ResponseField>
+</ResponseField>
+
+<Note>
+  **Kalshi** uses `last_price_dollars` from the market summary plus a
+  `/markets/trades?limit=1` lookup to enrich `size` and `side`. **Polymarket**
+  uses CLOB `GET /last-trade-price?token_id=…`.
+</Note>
+
+<RequestExample>
+
+```rust Rust
+use openpx::MidpointRequest;
+
+let t = ex.fetch_last_trade_price(MidpointRequest {
+    market_id: "KXBTC-25MAR14-T20000".into(),
+    ..Default::default()
+}).await?;
+```
+
+```python Python
+t = ex.fetch_last_trade_price(market_id="KXBTC-25MAR14-T20000")
+```
+
+```typescript TypeScript
+const t = await ex.fetchLastTradePrice({ marketId: "KXBTC-25MAR14-T20000" });
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+{ "price": 0.45, "side": "buy", "size": 100.0, "ts_ms": 1714000000000 }
+```
+
+</ResponseExample>

--- a/docs/api/pricing/fetch-midpoint.mdx
+++ b/docs/api/pricing/fetch-midpoint.mdx
@@ -1,0 +1,70 @@
+---
+title: "fetch_midpoint"
+sidebarTitle: "Fetch midpoint"
+openapi: GET /v1/pricing/fetch_midpoint
+playground: simple
+description: "Get the midpoint price for a market outcome."
+---
+
+Cheaper than [`fetch_orderbook`](/api/orderbook/fetch-orderbook) when only the
+mark price is needed.
+
+## Parameters
+
+<ParamField path="market_id" type="string" required>
+  Native market identifier — Kalshi ticker or Polymarket condition ID / token.
+</ParamField>
+
+<ParamField path="outcome" type="string?">
+  Outcome label (e.g. `"yes"`, `"no"`). Defaults to YES on Kalshi.
+</ParamField>
+
+<ParamField path="token_id" type="string?">
+  Polymarket CLOB token ID. When set, takes precedence over `market_id` +
+  `outcome`. On Kalshi this field is treated as an alternate ticker.
+</ParamField>
+
+## Returns
+
+<ResponseField name="midpoint" type="f64">
+  `(best_bid + best_ask) / 2` for the requested side.
+</ResponseField>
+
+<Note>
+  **Kalshi** derives this from the market summary endpoint — no native
+  `/midpoint` exists. **Polymarket** uses CLOB `GET /midpoint?token_id=…`.
+</Note>
+
+<RequestExample>
+
+```rust Rust
+use openpx::MidpointRequest;
+
+let req = MidpointRequest {
+    market_id: "KXBTC-25MAR14-T20000".into(),
+    outcome: Some("yes".into()),
+    ..Default::default()
+};
+let mid = ex.fetch_midpoint(req).await?;
+```
+
+```python Python
+mid = ex.fetch_midpoint(market_id="KXBTC-25MAR14-T20000", outcome="yes")
+```
+
+```typescript TypeScript
+const mid = await ex.fetchMidpoint({
+  marketId: "KXBTC-25MAR14-T20000",
+  outcome: "yes",
+});
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+0.44
+```
+
+</ResponseExample>

--- a/docs/api/pricing/fetch-midpoints-batch.mdx
+++ b/docs/api/pricing/fetch-midpoints-batch.mdx
@@ -1,0 +1,64 @@
+---
+title: "fetch_midpoints_batch"
+sidebarTitle: "Fetch midpoints (batch)"
+openapi: GET /v1/pricing/fetch_midpoints_batch
+playground: simple
+description: "Get midpoint prices for multiple markets in one round-trip."
+---
+
+Latency win for portfolio-wide PnL marks — single round-trip instead of N
+calls to [`fetch_midpoint`](/api/pricing/fetch-midpoint).
+
+## Parameters
+
+<ParamField path="market_ids" type="string[]" required>
+  **Kalshi:** market tickers (max 1000). **Polymarket:** CLOB token IDs.
+</ParamField>
+
+## Returns
+
+<ResponseField name="midpoints" type="Map<string, f64>">
+  Map keyed by the input identifier (token_id on Polymarket, ticker on Kalshi).
+  Markets without a two-sided book are omitted from the response.
+</ResponseField>
+
+<RequestExample>
+
+```rust Rust
+let mids = ex
+    .fetch_midpoints_batch(vec![
+        "KXBTC-25MAR14-T20000".into(),
+        "KXBTC-25MAR14-T25000".into(),
+    ])
+    .await?;
+for (id, mid) in &mids {
+    println!("{id}: {mid}");
+}
+```
+
+```python Python
+mids = ex.fetch_midpoints_batch([
+    "KXBTC-25MAR14-T20000",
+    "KXBTC-25MAR14-T25000",
+])
+```
+
+```typescript TypeScript
+const mids = await ex.fetchMidpointsBatch([
+  "KXBTC-25MAR14-T20000",
+  "KXBTC-25MAR14-T25000",
+]);
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+{
+  "KXBTC-25MAR14-T20000": 0.44,
+  "KXBTC-25MAR14-T25000": 0.21
+}
+```
+
+</ResponseExample>

--- a/docs/api/pricing/fetch-open-interest.mdx
+++ b/docs/api/pricing/fetch-open-interest.mdx
@@ -1,0 +1,50 @@
+---
+title: "fetch_open_interest"
+sidebarTitle: "Fetch open interest"
+openapi: GET /v1/pricing/fetch_open_interest
+playground: simple
+description: "Get total outstanding contracts (open interest) for a market."
+---
+
+## Parameters
+
+<ParamField path="market_id" type="string" required>
+  Native market identifier. Kalshi: ticker. Polymarket: condition ID.
+</ParamField>
+
+## Returns
+
+<ResponseField name="open_interest" type="f64">
+  Total outstanding contracts across both sides of the market.
+</ResponseField>
+
+<Note>
+  **Kalshi** reads `open_interest_fp` from the market summary endpoint.
+  **Polymarket** uses Data API `GET /oi?market={condition_id}` and returns an
+  explicit error when the Data-API miss has no value, rather than silently
+  returning 0.
+</Note>
+
+<RequestExample>
+
+```rust Rust
+let oi = ex.fetch_open_interest("KXBTC-25MAR14-T20000").await?;
+```
+
+```python Python
+oi = ex.fetch_open_interest("KXBTC-25MAR14-T20000")
+```
+
+```typescript TypeScript
+const oi = await ex.fetchOpenInterest("KXBTC-25MAR14-T20000");
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+4280.0
+```
+
+</ResponseExample>

--- a/docs/api/pricing/fetch-spread.mdx
+++ b/docs/api/pricing/fetch-spread.mdx
@@ -1,0 +1,61 @@
+---
+title: "fetch_spread"
+sidebarTitle: "Fetch spread"
+openapi: GET /v1/pricing/fetch_spread
+playground: simple
+description: "Get top-of-book bid, ask, and spread for a market outcome."
+---
+
+## Parameters
+
+Same shape as [`fetch_midpoint`](/api/pricing/fetch-midpoint) — uses the
+unified `MidpointRequest` type.
+
+<ParamField path="market_id" type="string" required />
+<ParamField path="outcome" type="string?" />
+<ParamField path="token_id" type="string?" />
+
+## Returns
+
+<ResponseField name="Spread" type="object">
+  <ResponseField name="bid" type="f64">Best bid.</ResponseField>
+  <ResponseField name="ask" type="f64">Best ask.</ResponseField>
+  <ResponseField name="spread" type="f64">`ask − bid`.</ResponseField>
+  <ResponseField name="ts_ms" type="i64?" />
+</ResponseField>
+
+<Note>
+  **Polymarket** `/spread` returns just the spread number; OpenPX combines it
+  with `/midpoint` to populate `bid` and `ask` (`mid ± spread/2`). When the
+  midpoint is unavailable, `bid` is reported as `0.0` and `ask` as `spread`.
+</Note>
+
+<RequestExample>
+
+```rust Rust
+use openpx::MidpointRequest;
+
+let s = ex.fetch_spread(MidpointRequest {
+    market_id: "KXBTC-25MAR14-T20000".into(),
+    ..Default::default()
+}).await?;
+println!("{} -> {} ({:.4} wide)", s.bid, s.ask, s.spread);
+```
+
+```python Python
+s = ex.fetch_spread(market_id="KXBTC-25MAR14-T20000")
+```
+
+```typescript TypeScript
+const s = await ex.fetchSpread({ marketId: "KXBTC-25MAR14-T20000" });
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+{ "bid": 0.42, "ask": 0.46, "spread": 0.04, "ts_ms": null }
+```
+
+</ResponseExample>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -51,7 +51,18 @@
           {
             "group": "Orderbook",
             "pages": [
-              "api/orderbook/fetch-orderbook"
+              "api/orderbook/fetch-orderbook",
+              "api/orderbook/fetch-orderbooks-batch"
+            ]
+          },
+          {
+            "group": "Pricing",
+            "pages": [
+              "api/pricing/fetch-midpoint",
+              "api/pricing/fetch-midpoints-batch",
+              "api/pricing/fetch-spread",
+              "api/pricing/fetch-last-trade-price",
+              "api/pricing/fetch-open-interest"
             ]
           },
           {

--- a/engine/exchanges/kalshi/src/exchange.rs
+++ b/engine/exchanges/kalshi/src/exchange.rs
@@ -1734,8 +1734,8 @@ impl Exchange for Kalshi {
 
         let tags = resp
             .tags_by_categories
-            .into_iter()
-            .flat_map(|(_category, names)| {
+            .into_values()
+            .flat_map(|names| {
                 names.into_iter().map(|name| Tag {
                     id: name.clone(),
                     slug: Some(name.to_ascii_lowercase().replace(' ', "-")),

--- a/engine/exchanges/kalshi/src/exchange.rs
+++ b/engine/exchanges/kalshi/src/exchange.rs
@@ -8,10 +8,10 @@ use tokio::sync::Mutex;
 use px_core::{
     canonical_event_id, manifests::KALSHI_MANIFEST, sort_asks, sort_bids, Candlestick, Event,
     EventsRequest, Exchange, ExchangeInfo, ExchangeManifest, FetchMarketsParams, FetchOrdersParams,
-    Fill, Market, MarketStatus, MarketStatusFilter, MarketTrade, MarketType, OpenPxError, Order,
-    OrderSide, OrderStatus, Orderbook, OutcomeToken, Position, PriceHistoryInterval,
-    PriceHistoryRequest, PriceLevel, RateLimiter, Series, SeriesRequest, SettlementSource, Tag,
-    TradesRequest,
+    Fill, LastTrade, Market, MarketStatus, MarketStatusFilter, MarketTrade, MarketType,
+    MidpointRequest, OpenPxError, Order, OrderSide, OrderStatus, Orderbook, OutcomeToken, Position,
+    PriceHistoryInterval, PriceHistoryRequest, PriceLevel, RateLimiter, Series, SeriesRequest,
+    SettlementSource, Spread, Tag, TradesRequest,
 };
 
 use crate::auth::KalshiAuth;
@@ -200,6 +200,22 @@ fn parse_kalshi_series(value: &serde_json::Value) -> Option<Series> {
         volume,
         last_updated_ts,
     })
+}
+
+/// Compute the midpoint for one market object. Returns `None` if either
+/// best-bid or best-ask is missing or zero.
+fn kalshi_midpoint_from_market(
+    market: &serde_json::Map<String, serde_json::Value>,
+    wants_no: bool,
+) -> Option<f64> {
+    let (bid_key, ask_key) = if wants_no {
+        ("no_bid_dollars", "no_ask_dollars")
+    } else {
+        ("yes_bid_dollars", "yes_ask_dollars")
+    };
+    let bid = parse_dollars(market, bid_key)?;
+    let ask = parse_dollars(market, ask_key)?;
+    Some((bid + ask) / 2.0)
 }
 
 pub struct Kalshi {
@@ -902,6 +918,23 @@ impl Kalshi {
             is_taker,
             fee,
             created_at,
+        })
+    }
+
+    /// Fetch a single market and return its raw JSON object. Shared helper for
+    /// the Batch 3 derived-pricing methods (midpoint, spread, last-trade, OI).
+    async fn fetch_kalshi_market_raw(
+        &self,
+        ticker: &str,
+    ) -> Result<serde_json::Map<String, serde_json::Value>, OpenPxError> {
+        #[derive(serde::Deserialize)]
+        struct Resp {
+            market: serde_json::Value,
+        }
+        let path = format!("/markets/{ticker}");
+        let resp: Resp = self.get(&path).await.map_err(to_openpx)?;
+        resp.market.as_object().cloned().ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::MarketNotFound(ticker.to_string()))
         })
     }
 
@@ -1722,6 +1755,254 @@ impl Exchange for Kalshi {
         Ok(tags)
     }
 
+    async fn fetch_orderbooks_batch(
+        &self,
+        market_ids: Vec<String>,
+    ) -> Result<Vec<Orderbook>, OpenPxError> {
+        if market_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        if market_ids.len() > 100 {
+            return Err(OpenPxError::Exchange(px_core::ExchangeError::InvalidOrder(
+                "fetch_orderbooks_batch: Kalshi limit is 100 tickers per request".into(),
+            )));
+        }
+
+        #[derive(serde::Deserialize)]
+        struct BatchResp {
+            #[serde(default)]
+            orderbooks: Vec<BatchEntry>,
+        }
+        #[derive(serde::Deserialize)]
+        struct BatchEntry {
+            ticker: String,
+            #[serde(default, alias = "orderbook")]
+            orderbook_fp: Option<OrderbookData>,
+        }
+        #[derive(serde::Deserialize)]
+        struct OrderbookData {
+            #[serde(default, alias = "yes")]
+            yes_dollars: Option<Vec<[String; 2]>>,
+            #[serde(default, alias = "no")]
+            no_dollars: Option<Vec<[String; 2]>>,
+        }
+
+        let tickers = market_ids.join(",");
+        let path = format!("/markets/orderbooks?tickers={tickers}");
+        let resp: BatchResp = self.get(&path).await.map_err(to_openpx)?;
+
+        let now = chrono::Utc::now();
+        let books = resp
+            .orderbooks
+            .into_iter()
+            .map(|entry| {
+                let mut bids = Vec::new();
+                let mut asks = Vec::new();
+                if let Some(data) = entry.orderbook_fp {
+                    if let Some(yes) = data.yes_dollars {
+                        for [p, s] in yes {
+                            if let (Ok(price), Ok(size)) =
+                                (p.parse::<f64>(), s.parse::<f64>())
+                            {
+                                if price > 0.0 && size > 0.0 {
+                                    bids.push(PriceLevel::new(price, size));
+                                }
+                            }
+                        }
+                    }
+                    if let Some(no) = data.no_dollars {
+                        for [p, s] in no {
+                            if let (Ok(price), Ok(size)) =
+                                (p.parse::<f64>(), s.parse::<f64>())
+                            {
+                                // NO bids at price X mean YES asks at 1-X.
+                                let yes_ask = 1.0 - price;
+                                if yes_ask > 0.0 && yes_ask < 1.0 && size > 0.0 {
+                                    asks.push(PriceLevel::new(yes_ask, size));
+                                }
+                            }
+                        }
+                    }
+                }
+                sort_bids(&mut bids);
+                sort_asks(&mut asks);
+                Orderbook {
+                    market_id: entry.ticker.clone(),
+                    asset_id: entry.ticker,
+                    bids,
+                    asks,
+                    last_update_id: None,
+                    timestamp: Some(now),
+                    hash: None,
+                }
+            })
+            .collect();
+        Ok(books)
+    }
+
+    async fn fetch_midpoint(&self, req: MidpointRequest) -> Result<f64, OpenPxError> {
+        let market = self.fetch_kalshi_market_raw(&req.market_id).await?;
+        let wants_no = req
+            .outcome
+            .as_deref()
+            .is_some_and(|o| o.eq_ignore_ascii_case("no"));
+        kalshi_midpoint_from_market(&market, wants_no).ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::Api(
+                "midpoint unavailable: market missing yes/no bid+ask".into(),
+            ))
+        })
+    }
+
+    async fn fetch_midpoints_batch(
+        &self,
+        market_ids: Vec<String>,
+    ) -> Result<HashMap<String, f64>, OpenPxError> {
+        if market_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        if market_ids.len() > 1000 {
+            return Err(OpenPxError::Exchange(px_core::ExchangeError::InvalidOrder(
+                "fetch_midpoints_batch: Kalshi limit is 1000 tickers per page".into(),
+            )));
+        }
+
+        #[derive(serde::Deserialize)]
+        struct MarketsResp {
+            #[serde(default)]
+            markets: Vec<serde_json::Value>,
+        }
+        let tickers = market_ids.join(",");
+        let path = format!("/markets?tickers={tickers}&limit={}", market_ids.len());
+        let resp: MarketsResp = self.get(&path).await.map_err(to_openpx)?;
+
+        let mut out = HashMap::with_capacity(resp.markets.len());
+        for m in resp.markets {
+            if let Some(obj) = m.as_object() {
+                if let (Some(ticker), Some(mid)) = (
+                    obj.get("ticker").and_then(|v| v.as_str()),
+                    kalshi_midpoint_from_market(obj, false),
+                ) {
+                    out.insert(ticker.to_string(), mid);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    async fn fetch_spread(&self, req: MidpointRequest) -> Result<Spread, OpenPxError> {
+        let market = self.fetch_kalshi_market_raw(&req.market_id).await?;
+        let wants_no = req
+            .outcome
+            .as_deref()
+            .is_some_and(|o| o.eq_ignore_ascii_case("no"));
+        let (bid_key, ask_key) = if wants_no {
+            ("no_bid_dollars", "no_ask_dollars")
+        } else {
+            ("yes_bid_dollars", "yes_ask_dollars")
+        };
+        let bid = parse_dollars(&market, bid_key);
+        let ask = parse_dollars(&market, ask_key);
+        match (bid, ask) {
+            (Some(bid), Some(ask)) => Ok(Spread {
+                bid,
+                ask,
+                spread: ask - bid,
+                ts_ms: None,
+            }),
+            _ => Err(OpenPxError::Exchange(px_core::ExchangeError::Api(
+                "spread unavailable: market missing bid+ask".into(),
+            ))),
+        }
+    }
+
+    async fn fetch_last_trade_price(
+        &self,
+        req: MidpointRequest,
+    ) -> Result<LastTrade, OpenPxError> {
+        let market = self.fetch_kalshi_market_raw(&req.market_id).await?;
+        let wants_no = req
+            .outcome
+            .as_deref()
+            .is_some_and(|o| o.eq_ignore_ascii_case("no"));
+        let key = if wants_no {
+            "no_last_price_dollars"
+        } else {
+            "last_price_dollars"
+        };
+        // `last_price_dollars` is YES; for NO we fall back to 1 - YES if the explicit
+        // field is absent (Kalshi only guarantees the YES variant).
+        let price = parse_dollars(&market, key)
+            .or_else(|| {
+                if wants_no {
+                    parse_dollars(&market, "last_price_dollars").map(|p| 1.0 - p)
+                } else {
+                    None
+                }
+            })
+            .ok_or_else(|| {
+                OpenPxError::Exchange(px_core::ExchangeError::Api(
+                    "last trade price unavailable".into(),
+                ))
+            })?;
+
+        // Kalshi doesn't carry side/size on the market summary; pull the head
+        // of /markets/trades for those.
+        let ticker = req.token_id.as_deref().unwrap_or(&req.market_id);
+        let trade_path = format!("/markets/trades?ticker={ticker}&limit=1");
+        let (side, size, ts_ms) = match self.get::<serde_json::Value>(&trade_path).await {
+            Ok(v) => v
+                .get("trades")
+                .and_then(|t| t.as_array())
+                .and_then(|arr| arr.first())
+                .map(|t| {
+                    let taker = t
+                        .get("taker_side")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("yes");
+                    let side = match (taker, wants_no) {
+                        ("yes", false) | ("no", true) => OrderSide::Buy,
+                        _ => OrderSide::Sell,
+                    };
+                    let size = t
+                        .get("count_fp")
+                        .and_then(|v| v.as_str().and_then(|s| s.parse::<f64>().ok()))
+                        .or_else(|| t.get("count").and_then(|v| v.as_f64()))
+                        .unwrap_or(0.0);
+                    let ts_ms = t
+                        .get("created_time")
+                        .and_then(|v| v.as_str())
+                        .and_then(parse_iso_datetime)
+                        .map(|dt| dt.timestamp_millis())
+                        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+                    (side, size, ts_ms)
+                })
+                .unwrap_or((OrderSide::Buy, 0.0, chrono::Utc::now().timestamp_millis())),
+            Err(_) => (OrderSide::Buy, 0.0, chrono::Utc::now().timestamp_millis()),
+        };
+
+        Ok(LastTrade {
+            price,
+            side,
+            size,
+            ts_ms,
+        })
+    }
+
+    async fn fetch_open_interest(&self, market_id: &str) -> Result<f64, OpenPxError> {
+        let market = self.fetch_kalshi_market_raw(market_id).await?;
+        parse_fp(&market, "open_interest_fp")
+            .or_else(|| {
+                market
+                    .get("open_interest")
+                    .and_then(|v| v.as_f64().or_else(|| v.as_i64().map(|i| i as f64)))
+            })
+            .ok_or_else(|| {
+                OpenPxError::Exchange(px_core::ExchangeError::Api(
+                    "open_interest_fp missing on market".into(),
+                ))
+            })
+    }
+
     async fn create_order(
         &self,
         market_id: &str,
@@ -1978,14 +2259,14 @@ impl Exchange for Kalshi {
             has_fetch_orderbook_history: false,
             has_fetch_events: true,
             has_fetch_event: true,
-            has_fetch_orderbooks_batch: false,
+            has_fetch_orderbooks_batch: true,
             has_fetch_series: true,
             has_fetch_series_one: true,
-            has_fetch_midpoint: false,
-            has_fetch_midpoints_batch: false,
-            has_fetch_spread: false,
-            has_fetch_last_trade_price: false,
-            has_fetch_open_interest: false,
+            has_fetch_midpoint: true,
+            has_fetch_midpoints_batch: true,
+            has_fetch_spread: true,
+            has_fetch_last_trade_price: true,
+            has_fetch_open_interest: true,
             has_fetch_user_trades: false,
             has_fetch_market_tags: true,
             has_cancel_all_orders: false,
@@ -2070,6 +2351,35 @@ mod parse_event_series_tests {
         let v = serde_json::json!({ "ticker": "KX", "title": "x" });
         let s = parse_kalshi_series(&v).expect("parse");
         assert!(s.volume.is_none());
+    }
+}
+
+#[cfg(test)]
+mod batch3_parser_tests {
+    use super::kalshi_midpoint_from_market;
+
+    #[test]
+    fn midpoint_yes_side() {
+        let mut m = serde_json::Map::new();
+        m.insert("yes_bid_dollars".into(), serde_json::json!("0.42"));
+        m.insert("yes_ask_dollars".into(), serde_json::json!("0.46"));
+        let mid = kalshi_midpoint_from_market(&m, false).expect("yes mid");
+        assert!((mid - 0.44).abs() < 1e-9);
+    }
+
+    #[test]
+    fn midpoint_no_side() {
+        let mut m = serde_json::Map::new();
+        m.insert("no_bid_dollars".into(), serde_json::json!("0.50"));
+        m.insert("no_ask_dollars".into(), serde_json::json!("0.55"));
+        let mid = kalshi_midpoint_from_market(&m, true).expect("no mid");
+        assert!((mid - 0.525).abs() < 1e-9);
+    }
+
+    #[test]
+    fn midpoint_returns_none_when_missing() {
+        let m = serde_json::Map::new();
+        assert!(kalshi_midpoint_from_market(&m, false).is_none());
     }
 }
 

--- a/engine/exchanges/kalshi/src/exchange.rs
+++ b/engine/exchanges/kalshi/src/exchange.rs
@@ -69,7 +69,10 @@ fn parse_iso_datetime(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
 
 fn parse_kalshi_event(value: &serde_json::Value) -> Option<Event> {
     let obj = value.as_object()?;
-    let id = obj.get("event_ticker").and_then(|v| v.as_str())?.to_string();
+    let id = obj
+        .get("event_ticker")
+        .and_then(|v| v.as_str())?
+        .to_string();
 
     let title = obj
         .get("title")
@@ -106,11 +109,7 @@ fn parse_kalshi_event(value: &serde_json::Value) -> Option<Event> {
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
-                .filter_map(|m| {
-                    m.get("ticker")
-                        .and_then(|v| v.as_str())
-                        .map(String::from)
-                })
+                .filter_map(|m| m.get("ticker").and_then(|v| v.as_str()).map(String::from))
                 .collect()
         })
         .unwrap_or_default();
@@ -1639,11 +1638,7 @@ impl Exchange for Kalshi {
 
         let resp: EventsResp = self.get(&path).await.map_err(to_openpx)?;
         let next_cursor = resp.cursor.filter(|c| !c.is_empty());
-        let events = resp
-            .events
-            .iter()
-            .filter_map(parse_kalshi_event)
-            .collect();
+        let events = resp.events.iter().filter_map(parse_kalshi_event).collect();
         Ok((events, next_cursor))
     }
 
@@ -1670,11 +1665,7 @@ impl Exchange for Kalshi {
             if let Some(markets) = resp.markets {
                 event.market_ids = markets
                     .iter()
-                    .filter_map(|m| {
-                        m.get("ticker")
-                            .and_then(|v| v.as_str())
-                            .map(String::from)
-                    })
+                    .filter_map(|m| m.get("ticker").and_then(|v| v.as_str()).map(String::from))
                     .collect();
             }
         }
@@ -1801,9 +1792,7 @@ impl Exchange for Kalshi {
                 if let Some(data) = entry.orderbook_fp {
                     if let Some(yes) = data.yes_dollars {
                         for [p, s] in yes {
-                            if let (Ok(price), Ok(size)) =
-                                (p.parse::<f64>(), s.parse::<f64>())
-                            {
+                            if let (Ok(price), Ok(size)) = (p.parse::<f64>(), s.parse::<f64>()) {
                                 if price > 0.0 && size > 0.0 {
                                     bids.push(PriceLevel::new(price, size));
                                 }
@@ -1812,9 +1801,7 @@ impl Exchange for Kalshi {
                     }
                     if let Some(no) = data.no_dollars {
                         for [p, s] in no {
-                            if let (Ok(price), Ok(size)) =
-                                (p.parse::<f64>(), s.parse::<f64>())
-                            {
+                            if let (Ok(price), Ok(size)) = (p.parse::<f64>(), s.parse::<f64>()) {
                                 // NO bids at price X mean YES asks at 1-X.
                                 let yes_ask = 1.0 - price;
                                 if yes_ask > 0.0 && yes_ask < 1.0 && size > 0.0 {
@@ -1915,10 +1902,7 @@ impl Exchange for Kalshi {
         }
     }
 
-    async fn fetch_last_trade_price(
-        &self,
-        req: MidpointRequest,
-    ) -> Result<LastTrade, OpenPxError> {
+    async fn fetch_last_trade_price(&self, req: MidpointRequest) -> Result<LastTrade, OpenPxError> {
         let market = self.fetch_kalshi_market_raw(&req.market_id).await?;
         let wants_no = req
             .outcome

--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -20,11 +20,11 @@ use tracing::info;
 use px_core::{
     canonical_event_id, manifests::POLYMARKET_MANIFEST, sort_asks, sort_bids, Candlestick, Event,
     EventsRequest, Exchange, ExchangeInfo, ExchangeManifest, FetchMarketsParams,
-    FetchOrdersParams, FetchUserActivityParams, Fill, Market, MarketStatus, MarketStatusFilter,
-    MarketTrade, MarketType, OpenPxError, Order, OrderSide, OrderStatus, Orderbook,
-    OrderbookHistoryRequest, OrderbookSnapshot, OutcomeToken, Position, PriceHistoryInterval,
-    PriceHistoryRequest, PriceLevel, PublicTrade, RateLimiter, Series, SeriesRequest,
-    SettlementSource, Tag, TradesRequest,
+    FetchOrdersParams, FetchUserActivityParams, Fill, LastTrade, Market, MarketStatus,
+    MarketStatusFilter, MarketTrade, MarketType, MidpointRequest, OpenPxError, Order, OrderSide,
+    OrderStatus, Orderbook, OrderbookHistoryRequest, OrderbookSnapshot, OutcomeToken, Position,
+    PriceHistoryInterval, PriceHistoryRequest, PriceLevel, PublicTrade, RateLimiter, Series,
+    SeriesRequest, SettlementSource, Spread, Tag, TradesRequest,
 };
 
 use crate::approvals::{AllowanceStatus, ApprovalRequest, ApprovalResponse, TokenApprover};
@@ -957,6 +957,38 @@ impl Polymarket {
 
     /// Fetch current open interest from Polymarket data-api.
     /// Returns the OI value (USDC-denominated outstanding token pairs).
+    /// Resolve a CLOB token ID from a `MidpointRequest`. Prefers the explicit
+    /// `req.token_id`; falls back to fetching the market and picking the YES
+    /// token (or the outcome-matched one) when only `market_id` is provided.
+    async fn resolve_token_id_for_pricing(
+        &self,
+        req: &MidpointRequest,
+    ) -> Result<String, OpenPxError> {
+        if let Some(t) = req.token_id.as_deref().filter(|s| !s.is_empty()) {
+            return Ok(t.to_string());
+        }
+        let market = self.fetch_market(&req.market_id).await?;
+        if let Some(outcome) = req.outcome.as_deref() {
+            if let Some(t) = market
+                .outcome_tokens
+                .iter()
+                .find(|t| t.outcome.eq_ignore_ascii_case(outcome))
+            {
+                return Ok(t.token_id.clone());
+            }
+        }
+        market
+            .token_id_yes
+            .clone()
+            .or_else(|| market.outcome_tokens.first().map(|t| t.token_id.clone()))
+            .ok_or_else(|| {
+                OpenPxError::Exchange(px_core::ExchangeError::Api(format!(
+                    "could not resolve token_id for market {}",
+                    req.market_id
+                )))
+            })
+    }
+
     pub async fn fetch_open_interest(
         &self,
         condition_id: &str,
@@ -3160,6 +3192,176 @@ impl Exchange for Polymarket {
         Ok(tags)
     }
 
+    async fn fetch_orderbooks_batch(
+        &self,
+        market_ids: Vec<String>,
+    ) -> Result<Vec<Orderbook>, OpenPxError> {
+        if market_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let body: Vec<serde_json::Value> = market_ids
+            .iter()
+            .map(|t| serde_json::json!({ "token_id": t }))
+            .collect();
+        let url = format!("{}/books", self.config.clob_url);
+        let resp = reqwest::Client::new()
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| OpenPxError::Exchange(px_core::ExchangeError::Api(e.to_string())))?;
+        if !resp.status().is_success() {
+            return Err(OpenPxError::Exchange(px_core::ExchangeError::Api(format!(
+                "polymarket /books HTTP {}",
+                resp.status()
+            ))));
+        }
+        let raw: Vec<serde_json::Value> = resp
+            .json()
+            .await
+            .map_err(|e| OpenPxError::Exchange(px_core::ExchangeError::Api(e.to_string())))?;
+        Ok(raw.iter().filter_map(parse_polymarket_book).collect())
+    }
+
+    async fn fetch_midpoint(&self, req: MidpointRequest) -> Result<f64, OpenPxError> {
+        let token_id = self.resolve_token_id_for_pricing(&req).await?;
+        let endpoint = format!("/midpoint?token_id={token_id}");
+        let v: serde_json::Value = self
+            .client
+            .get_clob(&endpoint)
+            .await
+            .map_err(|e| OpenPxError::Exchange(e.into()))?;
+        parse_polymarket_price_field(&v, "mid").ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::Api(
+                "polymarket /midpoint missing `mid` field".into(),
+            ))
+        })
+    }
+
+    async fn fetch_midpoints_batch(
+        &self,
+        market_ids: Vec<String>,
+    ) -> Result<HashMap<String, f64>, OpenPxError> {
+        if market_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let body: Vec<serde_json::Value> = market_ids
+            .iter()
+            .map(|t| serde_json::json!({ "token_id": t }))
+            .collect();
+        let url = format!("{}/midpoints", self.config.clob_url);
+        let resp = reqwest::Client::new()
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| OpenPxError::Exchange(px_core::ExchangeError::Api(e.to_string())))?;
+        if !resp.status().is_success() {
+            return Err(OpenPxError::Exchange(px_core::ExchangeError::Api(format!(
+                "polymarket /midpoints HTTP {}",
+                resp.status()
+            ))));
+        }
+        let raw: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| OpenPxError::Exchange(px_core::ExchangeError::Api(e.to_string())))?;
+        let mut out = HashMap::with_capacity(market_ids.len());
+        if let Some(map) = raw.as_object() {
+            for (k, v) in map {
+                if let Some(price) = v
+                    .as_f64()
+                    .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                {
+                    out.insert(k.clone(), price);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    async fn fetch_spread(&self, req: MidpointRequest) -> Result<Spread, OpenPxError> {
+        let token_id = self.resolve_token_id_for_pricing(&req).await?;
+        let endpoint = format!("/spread?token_id={token_id}");
+        let v: serde_json::Value = self
+            .client
+            .get_clob(&endpoint)
+            .await
+            .map_err(|e| OpenPxError::Exchange(e.into()))?;
+        let spread = parse_polymarket_price_field(&v, "spread").ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::Api(
+                "polymarket /spread missing `spread` field".into(),
+            ))
+        })?;
+        // /spread doesn't return bid/ask directly; complement with the midpoint
+        // when present so callers get a full Spread shape.
+        let mid = parse_polymarket_price_field(&v, "mid")
+            .or_else(|| parse_polymarket_price_field(&v, "midpoint"));
+        let (bid, ask) = if let Some(mid) = mid {
+            (mid - spread / 2.0, mid + spread / 2.0)
+        } else {
+            (0.0, spread)
+        };
+        Ok(Spread {
+            bid,
+            ask,
+            spread,
+            ts_ms: None,
+        })
+    }
+
+    async fn fetch_last_trade_price(
+        &self,
+        req: MidpointRequest,
+    ) -> Result<LastTrade, OpenPxError> {
+        let token_id = self.resolve_token_id_for_pricing(&req).await?;
+        let endpoint = format!("/last-trade-price?token_id={token_id}");
+        let v: serde_json::Value = self
+            .client
+            .get_clob(&endpoint)
+            .await
+            .map_err(|e| OpenPxError::Exchange(e.into()))?;
+        let price = parse_polymarket_price_field(&v, "price").ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::Api(
+                "polymarket /last-trade-price missing `price`".into(),
+            ))
+        })?;
+        let size = parse_polymarket_price_field(&v, "size").unwrap_or(0.0);
+        let side_str = v.get("side").and_then(|s| s.as_str()).unwrap_or("BUY");
+        let side = if side_str.eq_ignore_ascii_case("sell") {
+            OrderSide::Sell
+        } else {
+            OrderSide::Buy
+        };
+        let ts_ms = v
+            .get("timestamp")
+            .and_then(|t| {
+                t.as_i64()
+                    .or_else(|| t.as_str().and_then(|s| s.parse().ok()))
+            })
+            .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+        Ok(LastTrade {
+            price,
+            side,
+            size,
+            ts_ms,
+        })
+    }
+
+    async fn fetch_open_interest(&self, market_id: &str) -> Result<f64, OpenPxError> {
+        // Trait method takes a market_id; on Polymarket that's the conditionId.
+        // The inherent fetch_open_interest method returns Option<f64> on
+        // Data-API miss; lift to Result so missing OI is an explicit error.
+        Polymarket::fetch_open_interest(self, market_id)
+            .await
+            .map_err(|e| OpenPxError::Exchange(e.into()))?
+            .ok_or_else(|| {
+                OpenPxError::Exchange(px_core::ExchangeError::Api(format!(
+                    "polymarket /oi returned no value for {market_id}"
+                )))
+            })
+    }
+
     fn describe(&self) -> ExchangeInfo {
         let authed = self.config.is_authenticated();
         ExchangeInfo {
@@ -3186,14 +3388,14 @@ impl Exchange for Polymarket {
             has_fetch_orderbook_history: false,
             has_fetch_events: true,
             has_fetch_event: true,
-            has_fetch_orderbooks_batch: false,
+            has_fetch_orderbooks_batch: true,
             has_fetch_series: true,
             has_fetch_series_one: true,
-            has_fetch_midpoint: false,
-            has_fetch_midpoints_batch: false,
-            has_fetch_spread: false,
-            has_fetch_last_trade_price: false,
-            has_fetch_open_interest: false,
+            has_fetch_midpoint: true,
+            has_fetch_midpoints_batch: true,
+            has_fetch_spread: true,
+            has_fetch_last_trade_price: true,
+            has_fetch_open_interest: true,
             has_fetch_user_trades: false,
             has_fetch_market_tags: true,
             has_cancel_all_orders: false,
@@ -3351,6 +3553,77 @@ fn parse_polymarket_series(value: &serde_json::Value) -> Option<Series> {
     })
 }
 
+/// Parse a Polymarket CLOB /books or /book response object into an Orderbook.
+fn parse_polymarket_book(v: &serde_json::Value) -> Option<Orderbook> {
+    let obj = v.as_object()?;
+    let asset_id = obj
+        .get("asset_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let market_id = obj
+        .get("market")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| asset_id.clone());
+    let hash = obj.get("hash").and_then(|v| v.as_str()).map(String::from);
+    let timestamp = obj
+        .get("timestamp")
+        .and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        })
+        .and_then(chrono::DateTime::from_timestamp_millis);
+
+    let parse_levels = |key: &str| -> Vec<PriceLevel> {
+        obj.get(key)
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|level| {
+                        let lvl = level.as_object()?;
+                        let price = lvl.get("price").and_then(|p| {
+                            p.as_f64()
+                                .or_else(|| p.as_str().and_then(|s| s.parse().ok()))
+                        })?;
+                        let size = lvl.get("size").and_then(|s| {
+                            s.as_f64()
+                                .or_else(|| s.as_str().and_then(|s| s.parse().ok()))
+                        })?;
+                        if price > 0.0 && size > 0.0 {
+                            Some(PriceLevel::new(price, size))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+
+    let mut bids = parse_levels("bids");
+    let mut asks = parse_levels("asks");
+    sort_bids(&mut bids);
+    sort_asks(&mut asks);
+
+    Some(Orderbook {
+        market_id,
+        asset_id,
+        bids,
+        asks,
+        last_update_id: None,
+        timestamp,
+        hash,
+    })
+}
+
+fn parse_polymarket_price_field(v: &serde_json::Value, key: &str) -> Option<f64> {
+    v.get(key).and_then(|p| {
+        p.as_f64()
+            .or_else(|| p.as_str().and_then(|s| s.parse().ok()))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::polymarket_order_type;
@@ -3473,6 +3746,55 @@ mod tests {
         assert_eq!(s.frequency.as_deref(), Some("weekly"));
         assert_eq!(s.volume, Some(98_765.43));
         assert!(s.last_updated_ts.is_some());
+    }
+
+    // --- Batch 3 parser tests ---
+
+    use super::{parse_polymarket_book, parse_polymarket_price_field};
+
+    #[test]
+    fn parse_polymarket_book_orders_levels_and_carries_metadata() {
+        let v = serde_json::json!({
+            "asset_id": "0xTOKEN",
+            "market": "0xCONDITION",
+            "hash": "abc",
+            "timestamp": 1714000000000_i64,
+            "bids": [
+                { "price": "0.5", "size": "100" },
+                { "price": "0.6", "size": "50" },
+                { "price": "0.0", "size": "9" }
+            ],
+            "asks": [
+                { "price": "0.7", "size": "80" },
+                { "price": "0.65", "size": "40" }
+            ]
+        });
+        let b = parse_polymarket_book(&v).expect("parse");
+        assert_eq!(b.asset_id, "0xTOKEN");
+        assert_eq!(b.market_id, "0xCONDITION");
+        assert_eq!(b.hash.as_deref(), Some("abc"));
+        // bids sorted descending — best bid first.
+        assert!(b.best_bid().unwrap() >= 0.59);
+        // asks sorted ascending — best ask first.
+        assert!(b.best_ask().unwrap() <= 0.66);
+        // Zero-priced level filtered out.
+        assert_eq!(b.bids.len(), 2);
+    }
+
+    #[test]
+    fn parse_polymarket_price_field_handles_string_and_number() {
+        assert_eq!(
+            parse_polymarket_price_field(&serde_json::json!({"x": "0.42"}), "x"),
+            Some(0.42)
+        );
+        assert_eq!(
+            parse_polymarket_price_field(&serde_json::json!({"x": 0.42}), "x"),
+            Some(0.42)
+        );
+        assert_eq!(
+            parse_polymarket_price_field(&serde_json::json!({"y": "skip"}), "x"),
+            None
+        );
     }
 
     // --- Reconstructed OHLCV tests ---

--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -19,10 +19,10 @@ use tracing::info;
 
 use px_core::{
     canonical_event_id, manifests::POLYMARKET_MANIFEST, sort_asks, sort_bids, Candlestick, Event,
-    EventsRequest, Exchange, ExchangeInfo, ExchangeManifest, FetchMarketsParams,
-    FetchOrdersParams, FetchUserActivityParams, Fill, LastTrade, Market, MarketStatus,
-    MarketStatusFilter, MarketTrade, MarketType, MidpointRequest, OpenPxError, Order, OrderSide,
-    OrderStatus, Orderbook, OrderbookHistoryRequest, OrderbookSnapshot, OutcomeToken, Position,
+    EventsRequest, Exchange, ExchangeInfo, ExchangeManifest, FetchMarketsParams, FetchOrdersParams,
+    FetchUserActivityParams, Fill, LastTrade, Market, MarketStatus, MarketStatusFilter,
+    MarketTrade, MarketType, MidpointRequest, OpenPxError, Order, OrderSide, OrderStatus,
+    Orderbook, OrderbookHistoryRequest, OrderbookSnapshot, OutcomeToken, Position,
     PriceHistoryInterval, PriceHistoryRequest, PriceLevel, PublicTrade, RateLimiter, Series,
     SeriesRequest, SettlementSource, Spread, Tag, TradesRequest,
 };
@@ -3064,9 +3064,10 @@ impl Exchange for Polymarket {
             .await
             .map_err(|e| OpenPxError::Exchange(e.into()))?;
         let (raw, next_cursor) = match resp {
-            EventsResp::Wrapped { events, next_cursor } => {
-                (events, next_cursor.filter(|c| !c.is_empty()))
-            }
+            EventsResp::Wrapped {
+                events,
+                next_cursor,
+            } => (events, next_cursor.filter(|c| !c.is_empty())),
             EventsResp::Bare(events) => (events, None),
         };
         let events = raw.iter().filter_map(parse_polymarket_event).collect();
@@ -3076,9 +3077,7 @@ impl Exchange for Polymarket {
     async fn fetch_event(&self, id: &str) -> Result<Event, OpenPxError> {
         // Polymarket accepts both UUID-shaped IDs and slugs. UUID-like input
         // hits `/events/{id}`; everything else falls back to `/events/slug/{slug}`.
-        let endpoint = if id.chars().all(|c| c.is_ascii_hexdigit() || c == '-')
-            && id.len() >= 32
-        {
+        let endpoint = if id.chars().all(|c| c.is_ascii_hexdigit() || c == '-') && id.len() >= 32 {
             format!("/events/{id}")
         } else {
             format!("/events/slug/{id}")
@@ -3128,9 +3127,10 @@ impl Exchange for Polymarket {
             .await
             .map_err(|e| OpenPxError::Exchange(e.into()))?;
         let (raw, next_cursor) = match resp {
-            SeriesResp::Wrapped { series, next_cursor } => {
-                (series, next_cursor.filter(|c| !c.is_empty()))
-            }
+            SeriesResp::Wrapped {
+                series,
+                next_cursor,
+            } => (series, next_cursor.filter(|c| !c.is_empty())),
             SeriesResp::Bare(series) => (series, None),
         };
         let series = raw.iter().filter_map(parse_polymarket_series).collect();
@@ -3178,10 +3178,14 @@ impl Exchange for Polymarket {
             .iter()
             .filter_map(|t| {
                 let obj = t.as_object()?;
-                let id = obj
-                    .get("id")
-                    .and_then(|v| v.as_str().map(String::from).or_else(|| v.as_i64().map(|i| i.to_string())))?;
-                let name = obj.get("label").or_else(|| obj.get("name"))
+                let id = obj.get("id").and_then(|v| {
+                    v.as_str()
+                        .map(String::from)
+                        .or_else(|| v.as_i64().map(|i| i.to_string()))
+                })?;
+                let name = obj
+                    .get("label")
+                    .or_else(|| obj.get("name"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
@@ -3310,10 +3314,7 @@ impl Exchange for Polymarket {
         })
     }
 
-    async fn fetch_last_trade_price(
-        &self,
-        req: MidpointRequest,
-    ) -> Result<LastTrade, OpenPxError> {
+    async fn fetch_last_trade_price(&self, req: MidpointRequest) -> Result<LastTrade, OpenPxError> {
         let token_id = self.resolve_token_id_for_pricing(&req).await?;
         let endpoint = format!("/last-trade-price?token_id={token_id}");
         let v: serde_json::Value = self
@@ -3407,14 +3408,12 @@ impl Exchange for Polymarket {
 fn parse_polymarket_event(value: &serde_json::Value) -> Option<Event> {
     let obj = value.as_object()?;
 
-    let id = obj
-        .get("id")
-        .and_then(|v| {
-            v.as_str()
-                .map(String::from)
-                .or_else(|| v.as_i64().map(|i| i.to_string()))
-                .or_else(|| v.as_u64().map(|u| u.to_string()))
-        })?;
+    let id = obj.get("id").and_then(|v| {
+        v.as_str()
+            .map(String::from)
+            .or_else(|| v.as_i64().map(|i| i.to_string()))
+            .or_else(|| v.as_u64().map(|u| u.to_string()))
+    })?;
 
     let slug = obj.get("slug").and_then(|v| v.as_str()).map(String::from);
     let title = obj
@@ -3710,7 +3709,10 @@ mod tests {
         assert_eq!(e.volume, Some(1_234_567.5));
         assert_eq!(e.open_interest, Some(50_000.0));
         assert_eq!(e.mutually_exclusive, Some(true));
-        assert_eq!(e.market_ids, vec!["0xMARKET1".to_string(), "0xCID2".to_string()]);
+        assert_eq!(
+            e.market_ids,
+            vec!["0xMARKET1".to_string(), "0xCID2".to_string()]
+        );
         assert!(e.start_ts.is_some());
         assert!(e.end_ts.is_some());
     }

--- a/maintenance/manifest-allowlists/kalshi.txt
+++ b/maintenance/manifest-allowlists/kalshi.txt
@@ -74,3 +74,7 @@ fee_type                # Series.fee_type (e.g. "quadratic")
 category                # Series.category — used to filter SeriesRequest, not Market.category
 tags_by_categories      # Tags-by-category response wrapper (/search/tags_by_categories)
 /search/tags_by_categories  # URL path passed to self.get() — not a JSON key, test is over-broad
+
+# --- Pricing/books parsing (Batch 3 — LastTrade, Spread, Orderbooks helpers) ---
+trades                  # /markets/trades response wrapper read for fetch_last_trade_price
+taker_side              # Trade.taker_side (yes|no) used to derive LastTrade.side

--- a/maintenance/manifest-allowlists/polymarket.txt
+++ b/maintenance/manifest-allowlists/polymarket.txt
@@ -63,3 +63,6 @@ updatedAt               # Event/Series last_updated_ts (ISO 8601)
 recurrence              # Series.frequency alias on Gamma (some payloads use `recurrence`)
 frequency               # Series.frequency
 label                   # Tag.name on per-market tag objects (Gamma)
+
+# --- Pricing/books parsing (Batch 3 — Orderbook from /books, etc.) ---
+asset_id                # Polymarket /books response field — token_id of the orderbook entry


### PR DESCRIPTION
## Summary

Stacked on **#56**. Implements 6 pricing/book methods on both Kalshi and Polymarket — \`fetch_orderbooks_batch\`, \`fetch_midpoint\`, \`fetch_midpoints_batch\`, \`fetch_spread\`, \`fetch_last_trade_price\`, \`fetch_open_interest\`. Flips the corresponding \`has_*\` flags from \`false\` to \`true\`.

## Methods implemented (12 impls — 6 methods × 2 venues)

### Kalshi
| Method | Source |
|---|---|
| \`fetch_orderbooks_batch\` | \`GET /markets/orderbooks?tickers=A,B,…\` (max 100). YES side → bids; NO @ X → asks @ (1−X) |
| \`fetch_midpoint\` / \`fetch_midpoints_batch\` | derived from \`/markets/{ticker}\` or \`/markets?tickers=…\` (max 1000). Honors \`outcome=no\` |
| \`fetch_spread\` | derived from \`/markets/{ticker}\` |
| \`fetch_last_trade_price\` | \`last_price_dollars\` + \`/markets/trades?limit=1\` for size/side enrichment |
| \`fetch_open_interest\` | \`open_interest_fp\` field on \`/markets/{ticker}\` |

New helpers: \`fetch_kalshi_market_raw\` (one HTTP hop shared by all derived methods), \`kalshi_midpoint_from_market\` (pure, unit-tested).

### Polymarket
| Method | Endpoint |
|---|---|
| \`fetch_orderbooks_batch\` | \`POST /books\` with \`[{token_id}]\` body |
| \`fetch_midpoint\` | \`GET /midpoint?token_id=…\` |
| \`fetch_midpoints_batch\` | \`POST /midpoints\` with \`[{token_id}]\` body |
| \`fetch_spread\` | \`GET /spread?token_id=…\` (combines \`spread\` + \`mid\` for full Spread shape) |
| \`fetch_last_trade_price\` | \`GET /last-trade-price?token_id=…\` |
| \`fetch_open_interest\` | wraps existing inherent \`Polymarket::fetch_open_interest\` (Data API \`/oi\`); lifts Option miss to Result error |

New helpers: \`resolve_token_id_for_pricing\` (token_id direct or via fetch_market+outcome), \`parse_polymarket_book\` / \`parse_polymarket_price_field\` (pure, unit-tested; tolerate string-or-number price fields).

## Manifest allowlists

Added 2 Kalshi keys (\`trades\`, \`taker_side\`) and 1 Polymarket key (\`asset_id\`).

## Test plan

- [x] 3 new Kalshi parser tests (\`batch3_parser_tests\` module)
- [x] 2 new Polymarket parser tests
- [x] \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p px-core --test manifest_coverage\` green
- [ ] Live test against real Kalshi + Polymarket — gated on credentials; reviewer to spot-check pre-merge

## Stack

- Base: **#56** (chore/unified-api-14-methods)
- Independent of \\#54, \\#55 (V2 migration) and \\#57 (Batch 2 — events/series/tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)