### PR TITLE
feat(exchanges): implement fetch_user_trades on both venues (Batch 4)

### DIFF
--- a/docs/api/fills/fetch-user-trades.mdx
+++ b/docs/api/fills/fetch-user-trades.mdx
@@ -1,0 +1,123 @@
+---
+title: "fetch_user_trades"
+sidebarTitle: "Fetch user trades"
+openapi: GET /v1/fills/fetch_user_trades
+playground: simple
+description: "Page through a user's trade history."
+---
+
+Distinct from [`fetch_fills`](/api/fills/fetch-fills) — this surface returns
+the user-facing aggregated trade row with on-chain fields (`tx_hash`, `owner`)
+and `realized_pnl` where the venue exposes them.
+
+## Parameters
+
+<ParamField path="user_address" type="string?">
+  When `None`, returns the authenticated caller's own trades (auth required
+  on both venues). When `Some(addr)`, performs a public lookup for that
+  wallet — Polymarket only; Kalshi returns `Err(NotSupported)`.
+</ParamField>
+
+<ParamField path="market_id" type="string?">
+  Restrict to one market. Polymarket: condition ID. Kalshi: ticker.
+</ParamField>
+
+<ParamField path="side" type="OrderSide?">
+  Filter by side. Kalshi applies this client-side (the API doesn't filter).
+</ParamField>
+
+<ParamField path="start_ts" type="i64?">
+  Unix seconds. Kalshi-only — Polymarket Data `/trades` doesn't support
+  time bounds.
+</ParamField>
+
+<ParamField path="end_ts" type="i64?" />
+
+<ParamField path="limit" type="usize?">
+  Per-page cap: 1000 (Kalshi) / 500 (Polymarket).
+</ParamField>
+
+<ParamField path="cursor" type="string?">
+  Opaque cursor. **Polymarket** uses offset pagination — the cursor is the
+  numeric offset as a string and OpenPX synthesizes the next cursor only
+  when the page filled.
+</ParamField>
+
+## Returns
+
+<ResponseField name="trades" type="UserTrade[]">
+  <Expandable title="UserTrade">
+    <ResponseField name="id" type="string">Trade ID — Kalshi `trade_id` or Polymarket transaction hash.</ResponseField>
+    <ResponseField name="market_id" type="string" />
+    <ResponseField name="condition_id" type="string?">Polymarket only.</ResponseField>
+    <ResponseField name="asset_id" type="string?">Polymarket token id.</ResponseField>
+    <ResponseField name="side" type="OrderSide" />
+    <ResponseField name="size" type="f64" />
+    <ResponseField name="price" type="f64" />
+    <ResponseField name="role" type="LiquidityRole?">Kalshi: `maker` or `taker`. Polymarket: `None`.</ResponseField>
+    <ResponseField name="fee" type="f64?">Kalshi `fee_cost`. Polymarket: not on the trade row.</ResponseField>
+    <ResponseField name="realized_pnl" type="f64?">Polymarket only when present.</ResponseField>
+    <ResponseField name="tx_hash" type="string?">Polymarket only — Polygon transaction hash.</ResponseField>
+    <ResponseField name="owner" type="string?">Polymarket proxy wallet.</ResponseField>
+    <ResponseField name="ts_ms" type="i64" />
+  </Expandable>
+</ResponseField>
+
+<ResponseField name="cursor" type="string?">
+  `null` on the last page.
+</ResponseField>
+
+<RequestExample>
+
+```rust Rust
+use openpx::UserTradesRequest;
+
+// Caller's own trades (both venues, auth required).
+let (trades, _) = ex.fetch_user_trades(UserTradesRequest::default()).await?;
+
+// Public lookup of another wallet (Polymarket only).
+let (others, _) = ex.fetch_user_trades(UserTradesRequest {
+    user_address: Some("0xabc…".into()),
+    limit: Some(50),
+    ..Default::default()
+}).await?;
+```
+
+```python Python
+trades, cursor = ex.fetch_user_trades()
+others, _ = ex.fetch_user_trades(user_address="0xabc...", limit=50)
+```
+
+```typescript TypeScript
+const { trades } = await ex.fetchUserTrades({});
+const others = await ex.fetchUserTrades({ userAddress: "0xabc..." });
+```
+
+</RequestExample>
+
+<ResponseExample>
+
+```json 200
+{
+  "trades": [
+    {
+      "id": "0xdeadbeef…",
+      "market_id": "0xCONDITION",
+      "condition_id": "0xCONDITION",
+      "asset_id": "1029300…",
+      "side": "buy",
+      "size": 100.0,
+      "price": 0.45,
+      "role": null,
+      "fee": null,
+      "realized_pnl": 12.5,
+      "tx_hash": "0xdeadbeef…",
+      "owner": "0xabc…",
+      "ts_ms": 1714000000000
+    }
+  ],
+  "cursor": "100"
+}
+```
+
+</ResponseExample>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -104,6 +104,7 @@
             "group": "Fills",
             "pages": [
               "api/fills/fetch-fills",
+              "api/fills/fetch-user-trades",
               "api/fills/fetch-user-activity"
             ]
           },

--- a/engine/exchanges/kalshi/src/exchange.rs
+++ b/engine/exchanges/kalshi/src/exchange.rs
@@ -8,10 +8,11 @@ use tokio::sync::Mutex;
 use px_core::{
     canonical_event_id, manifests::KALSHI_MANIFEST, sort_asks, sort_bids, Candlestick, Event,
     EventsRequest, Exchange, ExchangeInfo, ExchangeManifest, FetchMarketsParams, FetchOrdersParams,
-    Fill, LastTrade, Market, MarketStatus, MarketStatusFilter, MarketTrade, MarketType,
-    MidpointRequest, OpenPxError, Order, OrderSide, OrderStatus, Orderbook, OutcomeToken, Position,
-    PriceHistoryInterval, PriceHistoryRequest, PriceLevel, RateLimiter, Series, SeriesRequest,
-    SettlementSource, Spread, Tag, TradesRequest,
+    Fill, LastTrade, LiquidityRole, Market, MarketStatus, MarketStatusFilter, MarketTrade,
+    MarketType, MidpointRequest, OpenPxError, Order, OrderSide, OrderStatus, Orderbook,
+    OutcomeToken, Position, PriceHistoryInterval, PriceHistoryRequest, PriceLevel, RateLimiter,
+    Series, SeriesRequest, SettlementSource, Spread, Tag, TradesRequest, UserTrade,
+    UserTradesRequest,
 };
 
 use crate::auth::KalshiAuth;
@@ -215,6 +216,75 @@ fn kalshi_midpoint_from_market(
     let bid = parse_dollars(market, bid_key)?;
     let ask = parse_dollars(market, ask_key)?;
     Some((bid + ask) / 2.0)
+}
+
+fn parse_kalshi_user_trade(value: &serde_json::Value) -> Option<UserTrade> {
+    let obj = value.as_object()?;
+    let id = obj
+        .get("trade_id")
+        .or_else(|| obj.get("fill_id"))
+        .and_then(|v| v.as_str())?
+        .to_string();
+    let market_id = obj
+        .get("ticker")
+        .or_else(|| obj.get("market_ticker"))
+        .and_then(|v| v.as_str())?
+        .to_string();
+
+    // Kalshi `side` is yes|no; `action` is buy|sell. The unified `OrderSide`
+    // is the actor's intent — `action` maps directly.
+    let side = match obj.get("action").and_then(|v| v.as_str()) {
+        Some("sell") => OrderSide::Sell,
+        _ => OrderSide::Buy,
+    };
+
+    let outcome_no = obj
+        .get("side")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| s.eq_ignore_ascii_case("no"));
+    let price = if outcome_no {
+        parse_dollars(obj, "no_price_dollars")
+    } else {
+        parse_dollars(obj, "yes_price_dollars")
+    }?;
+
+    let size = parse_fp(obj, "count_fp").or_else(|| {
+        obj.get("count")
+            .and_then(|v| v.as_f64().or_else(|| v.as_i64().map(|i| i as f64)))
+    })?;
+
+    let role = obj.get("is_taker").and_then(|v| v.as_bool()).map(|t| {
+        if t {
+            LiquidityRole::Taker
+        } else {
+            LiquidityRole::Maker
+        }
+    });
+
+    let fee = parse_dollars(obj, "fee_cost");
+
+    let ts_ms = obj
+        .get("created_time")
+        .and_then(|v| v.as_str())
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|dt| dt.timestamp_millis())
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+
+    Some(UserTrade {
+        id,
+        market_id,
+        condition_id: None,
+        asset_id: None,
+        side,
+        size,
+        price,
+        role,
+        fee,
+        realized_pnl: None,
+        tx_hash: None,
+        owner: None,
+        ts_ms,
+    })
 }
 
 pub struct Kalshi {
@@ -1972,6 +2042,57 @@ impl Exchange for Kalshi {
         })
     }
 
+    async fn fetch_user_trades(
+        &self,
+        req: UserTradesRequest,
+    ) -> Result<(Vec<UserTrade>, Option<String>), OpenPxError> {
+        // Kalshi only exposes the caller's own fills; public lookup of another
+        // user is unsupported.
+        if req.user_address.is_some() {
+            return Err(OpenPxError::Exchange(px_core::ExchangeError::NotSupported(
+                "kalshi fetch_user_trades(user_address): public lookup not exposed".into(),
+            )));
+        }
+        self.ensure_auth().map_err(to_openpx)?;
+
+        #[derive(serde::Deserialize)]
+        struct FillsResp {
+            cursor: Option<String>,
+            #[serde(default)]
+            fills: Vec<serde_json::Value>,
+        }
+
+        let limit = req.limit.unwrap_or(100).clamp(1, 1000);
+        let mut path = format!("/portfolio/fills?limit={limit}");
+        if let Some(market) = req.market_id.as_deref() {
+            path.push_str(&format!("&ticker={market}"));
+        }
+        if let Some(c) = req.cursor.as_deref().filter(|c| !c.is_empty()) {
+            path.push_str(&format!("&cursor={c}"));
+        }
+        if let Some(ts) = req.start_ts {
+            path.push_str(&format!("&min_ts={ts}"));
+        }
+        if let Some(ts) = req.end_ts {
+            path.push_str(&format!("&max_ts={ts}"));
+        }
+
+        let resp: FillsResp = self.get(&path).await.map_err(to_openpx)?;
+        let next_cursor = resp.cursor.filter(|c| !c.is_empty());
+
+        // Kalshi `side` filter is post-fetch — the API only filters by ticker /
+        // order_id. Keep this defensive client-side filter so callers see only
+        // the side they asked for.
+        let want_side = req.side;
+        let trades = resp
+            .fills
+            .iter()
+            .filter_map(parse_kalshi_user_trade)
+            .filter(|t| want_side.map(|s| t.side == s).unwrap_or(true))
+            .collect();
+        Ok((trades, next_cursor))
+    }
+
     async fn fetch_open_interest(&self, market_id: &str) -> Result<f64, OpenPxError> {
         let market = self.fetch_kalshi_market_raw(market_id).await?;
         parse_fp(&market, "open_interest_fp")
@@ -2251,7 +2372,7 @@ impl Exchange for Kalshi {
             has_fetch_spread: true,
             has_fetch_last_trade_price: true,
             has_fetch_open_interest: true,
-            has_fetch_user_trades: false,
+            has_fetch_user_trades: self.config.is_authenticated(),
             has_fetch_market_tags: true,
             has_cancel_all_orders: false,
             has_create_orders_batch: false,

--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -24,7 +24,7 @@ use px_core::{
     MarketTrade, MarketType, MidpointRequest, OpenPxError, Order, OrderSide, OrderStatus,
     Orderbook, OrderbookHistoryRequest, OrderbookSnapshot, OutcomeToken, Position,
     PriceHistoryInterval, PriceHistoryRequest, PriceLevel, PublicTrade, RateLimiter, Series,
-    SeriesRequest, SettlementSource, Spread, Tag, TradesRequest,
+    SeriesRequest, SettlementSource, Spread, Tag, TradesRequest, UserTrade, UserTradesRequest,
 };
 
 use crate::approvals::{AllowanceStatus, ApprovalRequest, ApprovalResponse, TokenApprover};
@@ -3363,6 +3363,67 @@ impl Exchange for Polymarket {
             })
     }
 
+    async fn fetch_user_trades(
+        &self,
+        req: UserTradesRequest,
+    ) -> Result<(Vec<UserTrade>, Option<String>), OpenPxError> {
+        // Default to the configured wallet (Funder) when no user_address is given.
+        let user = if let Some(addr) = req.user_address.as_deref().filter(|s| !s.is_empty()) {
+            addr.to_string()
+        } else {
+            self.owner_address()
+                .map_err(|e| OpenPxError::Exchange(e.into()))?
+        };
+
+        // Polymarket Data /trades is offset-paginated: `limit` + `offset`.
+        // Translate cursor → offset (numeric string).
+        let limit = req.limit.unwrap_or(100).clamp(1, 500);
+        let offset: usize = req
+            .cursor
+            .as_deref()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
+        let mut endpoint = format!("/trades?user={user}&limit={limit}&offset={offset}");
+        if let Some(market) = req.market_id.as_deref() {
+            endpoint.push_str(&format!("&market={market}"));
+        }
+        if let Some(side) = req.side {
+            let s = match side {
+                OrderSide::Buy => "BUY",
+                OrderSide::Sell => "SELL",
+            };
+            endpoint.push_str(&format!("&side={s}"));
+        }
+
+        // Data API uses a separate base URL; doesn't go through `client.get_clob`.
+        let url = format!("{}{}", self.config.data_api_url, endpoint);
+        let resp = reqwest::get(&url)
+            .await
+            .map_err(|e| OpenPxError::Network(px_core::NetworkError::Http(e.to_string())))?;
+        if !resp.status().is_success() {
+            return Err(OpenPxError::Exchange(px_core::ExchangeError::Api(format!(
+                "polymarket /trades HTTP {}",
+                resp.status()
+            ))));
+        }
+        let raw: Vec<serde_json::Value> = resp
+            .json()
+            .await
+            .map_err(|e| OpenPxError::Exchange(px_core::ExchangeError::Api(e.to_string())))?;
+
+        let trades: Vec<UserTrade> = raw.iter().filter_map(parse_polymarket_user_trade).collect();
+
+        // Synthesize a next-cursor from the offset only when the page filled —
+        // a partial page implies we've reached the tail.
+        let next_cursor = if trades.len() == limit {
+            Some((offset + limit).to_string())
+        } else {
+            None
+        };
+        Ok((trades, next_cursor))
+    }
+
     fn describe(&self) -> ExchangeInfo {
         let authed = self.config.is_authenticated();
         ExchangeInfo {
@@ -3397,7 +3458,7 @@ impl Exchange for Polymarket {
             has_fetch_spread: true,
             has_fetch_last_trade_price: true,
             has_fetch_open_interest: true,
-            has_fetch_user_trades: false,
+            has_fetch_user_trades: true,
             has_fetch_market_tags: true,
             has_cancel_all_orders: false,
             has_create_orders_batch: false,
@@ -3549,6 +3610,85 @@ fn parse_polymarket_series(value: &serde_json::Value) -> Option<Series> {
         fee_type: None,
         volume,
         last_updated_ts,
+    })
+}
+
+fn parse_polymarket_user_trade(value: &serde_json::Value) -> Option<UserTrade> {
+    let obj = value.as_object()?;
+
+    let id = obj
+        .get("id")
+        .or_else(|| obj.get("transactionHash"))
+        .and_then(|v| v.as_str())?
+        .to_string();
+
+    // Data API returns `market` as the conditionId; `asset` is the token id.
+    let condition_id = obj
+        .get("market")
+        .or_else(|| obj.get("conditionId"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let asset_id = obj
+        .get("asset")
+        .or_else(|| obj.get("asset_id"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let market_id = condition_id.clone().unwrap_or_default();
+
+    let side = match obj.get("side").and_then(|v| v.as_str()) {
+        Some(s) if s.eq_ignore_ascii_case("sell") => OrderSide::Sell,
+        _ => OrderSide::Buy,
+    };
+
+    let parse_f64 = |key: &str| {
+        obj.get(key).and_then(|v| {
+            v.as_f64()
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+        })
+    };
+    let size = parse_f64("size")?;
+    let price = parse_f64("price")?;
+
+    let tx_hash = obj
+        .get("transactionHash")
+        .or_else(|| obj.get("transaction_hash"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let owner = obj
+        .get("proxyWallet")
+        .or_else(|| obj.get("user"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let ts_ms = obj
+        .get("timestamp")
+        .or_else(|| obj.get("matchTime"))
+        .and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                .or_else(|| {
+                    v.as_str()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .map(|dt| dt.timestamp_millis())
+                })
+        })
+        .unwrap_or_else(|| chrono::Utc::now().timestamp_millis());
+
+    Some(UserTrade {
+        id,
+        market_id,
+        condition_id,
+        asset_id,
+        side,
+        size,
+        price,
+        role: None,
+        fee: None,
+        realized_pnl: parse_f64("realizedPnl").or_else(|| parse_f64("realized_pnl")),
+        tx_hash,
+        owner,
+        ts_ms,
     })
 }
 

--- a/maintenance/manifest-allowlists/kalshi.txt
+++ b/maintenance/manifest-allowlists/kalshi.txt
@@ -78,3 +78,8 @@ tags_by_categories      # Tags-by-category response wrapper (/search/tags_by_cat
 # --- Pricing/books parsing (Batch 3 — LastTrade, Spread, Orderbooks helpers) ---
 trades                  # /markets/trades response wrapper read for fetch_last_trade_price
 taker_side              # Trade.taker_side (yes|no) used to derive LastTrade.side
+
+# --- User trades parsing (Batch 4 — UserTrade model, distinct from Fill) ---
+trade_id                # UserTrade.id source on /portfolio/fills (Kalshi treats trade_id == fill_id)
+yes_price_dollars       # UserTrade.price (yes side, fixed-point dollar string)
+no_price_dollars        # UserTrade.price (no side, fixed-point dollar string)

--- a/maintenance/manifest-allowlists/polymarket.txt
+++ b/maintenance/manifest-allowlists/polymarket.txt
@@ -64,5 +64,7 @@ recurrence              # Series.frequency alias on Gamma (some payloads use `re
 frequency               # Series.frequency
 label                   # Tag.name on per-market tag objects (Gamma)
 
-# --- Pricing/books parsing (Batch 3 — Orderbook from /books, etc.) ---
-asset_id                # Polymarket /books response field — token_id of the orderbook entry
+# --- Pricing/books + user trades parsing (Batches 3+4) ---
+asset_id                # Polymarket /books + Data API /trades response field — token_id of the entry
+transaction_hash        # Snake-case alias for transactionHash on some Data API rows
+user                    # Snake-case alias for proxyWallet on some Data API rows


### PR DESCRIPTION
## Summary

Stacked on **#56**. Implements \`fetch_user_trades\` on Kalshi and Polymarket. Honors the unified \`user_address: Option<String>\` semantics agreed during planning:

- \`None\` → caller's own trades (auth required on both venues).
- \`Some(addr)\` → public lookup. Polymarket queries the wallet via Data API; Kalshi returns \`Err(NotSupported)\` (no public-by-wallet endpoint).

## Methods implemented (2 impls — 1 method × 2 venues)

### Kalshi (\`engine/exchanges/kalshi/src/exchange.rs\`)
- \`GET /portfolio/fills?ticker&min_ts&max_ts&limit&cursor\` (auth required, cursor-paginated).
- Maps fills → \`UserTrade\` with \`realized_pnl: None\`, \`tx_hash: None\`, \`owner: None\` — Kalshi doesn't carry these on the fill row.
- Kalshi \`side\` (yes|no) drives which fixed-point price field is read (\`yes_price_dollars\` vs \`no_price_dollars\`); Kalshi \`action\` (buy|sell) maps to unified \`OrderSide\`.
- \`req.side\` filter is applied client-side (Kalshi API doesn't accept side filter on \`/portfolio/fills\`).
- Flag flips: \`has_fetch_user_trades = self.config.is_authenticated()\`.

### Polymarket (\`engine/exchanges/polymarket/src/exchange.rs\`)
- Data API \`GET /trades?user=<addr>&market&side&limit&offset\` (public, no auth — \`user\` falls back to \`self.owner_address()\` when not given).
- Polymarket Data uses **offset pagination**; the unified cursor is the numeric offset as a string. \`next_cursor\` is synthesized only when the page filled — partial page implies tail.
- Maps Polymarket trade rows → \`UserTrade\` with on-chain enrichment: \`tx_hash\`, \`owner\` (proxyWallet), \`realized_pnl\` (when present in Data API response).
- Flag flips: \`has_fetch_user_trades = true\`.

## Manifest allowlists

- 3 new Kalshi keys: \`trade_id\`, \`yes_price_dollars\`, \`no_price_dollars\`
- 3 new Polymarket keys: \`asset_id\`, \`transaction_hash\` (snake_case alias), \`user\` (snake_case alias)

## Test plan

- [x] \`cargo test --workspace\` green
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`cargo test -p px-core --test manifest_coverage\` green
- [ ] Live test against real Kalshi + Polymarket — gated on credentials; reviewer to spot-check pre-merge

## Stack

- Base: **#56** (chore/unified-api-14-methods)
- Independent of \\#54, \\#55, \\#57, \\#58

🤖 Generated with [Claude Code](https://claude.com/claude-code)