### PR TITLE
feat(sports): scaffold SportsProvider trait + unified schema (PR 1/N)

### DIFF
--- a/engine/core/src/models/mod.rs
+++ b/engine/core/src/models/mod.rs
@@ -6,6 +6,7 @@ mod orderbook;
 mod position;
 mod series;
 mod sport;
+mod sports;
 mod tag;
 mod trade;
 
@@ -17,5 +18,6 @@ pub use orderbook::*;
 pub use position::*;
 pub use series::*;
 pub use sport::*;
+pub use sports::*;
 pub use tag::*;
 pub use trade::*;

--- a/engine/core/src/models/sports/game.rs
+++ b/engine/core/src/models/sports/game.rs
@@ -1,0 +1,84 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Opaque, provider-scoped game identifier. Only meaningful in the context of
+/// the `Game::provider` that produced it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct GameId(pub String);
+
+impl GameId {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for GameId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A scheduled, live, or completed sporting event. The unified shape across
+/// every `SportsProvider`. Provider-specific fields stay in the provider's
+/// own DTO and are only surfaced via the provider's inherent methods.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Game {
+    pub id: GameId,
+    /// Canonical league id (`League::id`). Always set.
+    pub league: String,
+    /// Home team display name. May be `None` on providers that don't model
+    /// teams as first-class (Kalshi).
+    pub home_team: Option<String>,
+    /// Away team display name. Same caveat as `home_team`.
+    pub away_team: Option<String>,
+    /// Scheduled start time. May be `None` for providers that publish
+    /// games only after kickoff.
+    pub start_time: Option<DateTime<Utc>>,
+    pub status: GameStatus,
+    /// Verbatim status string from the provider before normalization. Useful
+    /// when `status` is `GameStatus::Unknown` (caller can branch on `raw_status`).
+    pub raw_status: Option<String>,
+    /// Provider id this game was fetched from (e.g., "espn", "kalshi", "polymarket").
+    pub provider: String,
+}
+
+/// Normalized lifecycle status. Unit enum so manifest `status_map`s can be
+/// declared as `&'static [(&'static str, GameStatus)]`. Providers ship a wide
+/// vocabulary of status strings; anything we can't map normalizes to `Unknown`
+/// and the original value is preserved in `Game::raw_status`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum GameStatus {
+    Scheduled,
+    Live,
+    Final,
+    Postponed,
+    Cancelled,
+    Unknown,
+}
+
+/// Filter for `SportsProvider::list_games`. All fields optional — providers
+/// apply only those they support and ignore the rest.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct GameFilter {
+    /// Restrict to one league id (e.g., "nfl").
+    pub league: Option<String>,
+    /// Restrict to games on a specific calendar day (UTC).
+    pub date: Option<DateTime<Utc>>,
+    /// Restrict to a normalized status.
+    pub status: Option<GameStatus>,
+    /// Restrict to games involving a team (matches home or away).
+    pub team: Option<String>,
+    /// Page size hint; providers may clamp.
+    pub limit: Option<usize>,
+    /// Opaque pagination cursor from a previous response.
+    pub cursor: Option<String>,
+}

--- a/engine/core/src/models/sports/game_state.rs
+++ b/engine/core/src/models/sports/game_state.rs
@@ -1,0 +1,40 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{GameId, GameStatus};
+
+/// Live or post-game state for a single `Game`. The unit emitted by
+/// `SportsProvider::subscribe_game_state`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct GameState {
+    pub game_id: GameId,
+    pub status: GameStatus,
+    /// Verbatim status string from the provider; useful when `status` is `Unknown`.
+    pub raw_status: Option<String>,
+    /// Current score. `None` until the game starts.
+    pub score: Option<Score>,
+    /// Provider-formatted period label (e.g., "Q2", "Halftime", "9th Inning").
+    /// Kept as a string because semantics differ per sport.
+    pub period: Option<String>,
+    /// Provider-formatted clock (e.g., "12:34"). Remaining-vs-elapsed semantics
+    /// are sport-specific; surfaces verbatim.
+    pub clock: Option<String>,
+    pub live: bool,
+    pub ended: bool,
+    /// Timestamp this state was observed (provider-supplied if available, else
+    /// receive-time on the client).
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Score in a head-to-head sport. For exotic formats (esports best-of-N,
+/// golf cumulative, etc.) providers populate `raw` and leave home/away `None`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Score {
+    pub home: Option<u32>,
+    pub away: Option<u32>,
+    /// Verbatim provider score string when home/away can't be normalized
+    /// (e.g., "0-0|2-0|Bo3", "+5/-3").
+    pub raw: Option<String>,
+}

--- a/engine/core/src/models/sports/mod.rs
+++ b/engine/core/src/models/sports/mod.rs
@@ -1,0 +1,7 @@
+mod game;
+mod game_state;
+mod sport;
+
+pub use game::*;
+pub use game_state::*;
+pub use sport::*;

--- a/engine/core/src/models/sports/sport.rs
+++ b/engine/core/src/models/sports/sport.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+/// A top-level sport category (e.g., football, basketball, hockey).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Sport {
+    /// Canonical sport id (lowercase, no spaces). Stable across providers.
+    pub id: String,
+    /// Human-readable display name.
+    pub name: String,
+}
+
+/// A specific competition within a sport (e.g., NFL, NBA, English Premier League).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct League {
+    /// Canonical league id (lowercase, no spaces). Stable across providers.
+    pub id: String,
+    /// Human-readable display name.
+    pub name: String,
+    /// Back-reference to the parent `Sport::id`.
+    pub sport_id: String,
+    /// Common abbreviation (e.g., "NFL", "NBA"). Optional — not every league has one.
+    pub abbreviation: Option<String>,
+}

--- a/engine/sports/Cargo.toml
+++ b/engine/sports/Cargo.toml
@@ -9,6 +9,10 @@ readme = "README.md"
 keywords = ["sports", "websocket", "live-scores", "prediction-market"]
 categories = ["api-bindings"]
 
+[features]
+default = []
+schema = ["dep:schemars", "px-core/schema"]
+
 [dependencies]
 px-core = { workspace = true }
 tokio = { workspace = true }
@@ -18,3 +22,4 @@ futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+schemars = { version = "0.8", features = ["chrono", "smallvec"], optional = true }

--- a/engine/sports/src/lib.rs
+++ b/engine/sports/src/lib.rs
@@ -1,3 +1,21 @@
+//! `px-sports`: unified sports research surface.
+//!
+//! This crate owns the `SportsProvider` trait + manifest scaffolding that
+//! every provider (ESPN, plus Kalshi/Polymarket sports impls in their
+//! respective exchange crates) implements.
+//!
+//! The legacy `SportsWebSocket` below is the original Polymarket-Sports
+//! WebSocket client. It will move to `engine/exchanges/polymarket/` in the
+//! next PR and become the internal driver behind Polymarket's
+//! `impl SportsProvider`. It is kept here in this PR to keep the change
+//! surface single-purpose (scaffolding only).
+
+pub mod manifest;
+pub mod provider;
+
+pub use manifest::{FieldMapping, SportsManifest, Transform};
+pub use provider::{GameStateStream, SportsCapabilities, SportsProvider};
+
 use std::sync::Arc;
 
 use futures::StreamExt;

--- a/engine/sports/src/manifest.rs
+++ b/engine/sports/src/manifest.rs
@@ -1,0 +1,79 @@
+//! Per-provider field mapping manifest. Mirrors the exchange manifest pattern
+//! (`engine/core/src/exchange/manifest.rs`): every JSON key a sports provider
+//! reads must either be declared here or appear in the per-provider
+//! `maintenance/manifest-allowlists/sports-<id>.txt` file. This is what
+//! turns the unified schema into an auditable contract.
+
+use px_core::models::GameStatus;
+
+#[derive(Debug, Clone)]
+pub struct SportsManifest {
+    /// Provider id (e.g., "espn", "kalshi", "polymarket").
+    pub id: &'static str,
+
+    /// Human-readable name.
+    pub name: &'static str,
+
+    /// Base API URL.
+    pub base_url: &'static str,
+
+    /// Endpoint that returns a list of games (relative to `base_url`).
+    pub games_endpoint: &'static str,
+
+    /// Field mappings from raw provider JSON to unified `Game` / `GameState`.
+    pub field_mappings: &'static [FieldMapping],
+
+    /// Status value mappings (provider status string → `GameStatus`).
+    /// Lowercase at definition time for case-insensitive lookup without alloc.
+    pub status_map: &'static [(&'static str, GameStatus)],
+}
+
+impl SportsManifest {
+    /// Look up the unified `GameStatus` for a provider-supplied status string.
+    pub fn map_status(&self, raw: &str) -> Option<GameStatus> {
+        self.status_map
+            .iter()
+            .find(|(s, _)| s.eq_ignore_ascii_case(raw))
+            .map(|(_, status)| *status)
+    }
+
+    /// Get a field mapping by unified field name.
+    pub fn get_field_mapping(&self, unified_field: &str) -> Option<&FieldMapping> {
+        self.field_mappings
+            .iter()
+            .find(|m| m.unified_field == unified_field)
+    }
+}
+
+/// Mapping from raw provider JSON field to unified field on `Game`/`GameState`.
+#[derive(Debug, Clone)]
+pub struct FieldMapping {
+    /// Target field on the unified type (e.g., "home_team", "score.home").
+    pub unified_field: &'static str,
+    /// Source path(s) in raw JSON (fallback chain for providers that vary
+    /// field names across endpoints).
+    pub source_paths: &'static [&'static str],
+    /// Transformation to apply when reading the source value.
+    pub transform: Transform,
+    /// Whether the field can be absent or null in the source payload.
+    pub nullable: bool,
+}
+
+/// Transformation applied when mapping a source field. Intentionally smaller
+/// than the exchange `Transform` enum — sports payloads don't have the
+/// fixed-point quirks of trading endpoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transform {
+    /// Use the value directly with no conversion.
+    Direct,
+    /// Unix timestamp (seconds) → `DateTime<Utc>`.
+    UnixSecsToDateTime,
+    /// Unix timestamp (milliseconds) → `DateTime<Utc>`.
+    UnixMillisToDateTime,
+    /// ISO8601 string → `DateTime<Utc>`.
+    Iso8601ToDateTime,
+    /// String/Float → integer.
+    ParseInt,
+    /// Nested path extraction (dot-notation handled by `source_paths`).
+    NestedPath,
+}

--- a/engine/sports/src/provider.rs
+++ b/engine/sports/src/provider.rs
@@ -1,0 +1,102 @@
+use futures::Stream;
+use serde::Serialize;
+use std::pin::Pin;
+
+use px_core::error::{OpenPxError, WebSocketError};
+use px_core::models::{Game, GameFilter, GameId, GameState, Sport};
+
+use crate::manifest::SportsManifest;
+
+/// Stream of live `GameState` updates emitted by a `SportsProvider`. Mirrors
+/// the `SportsStream` shape on the WebSocket side but carries the unified
+/// `GameState` instead of a provider-specific DTO.
+pub type GameStateStream = Pin<Box<dyn Stream<Item = Result<GameState, WebSocketError>> + Send>>;
+
+/// Read-only sports data provider. Implemented by ESPN (pure data) and by the
+/// existing exchanges (Kalshi, Polymarket) that also expose sports primitives.
+///
+/// The trait covers only the parity-core: concepts present across all current
+/// providers. Provider-specific endpoints (ESPN's news/standings/play-by-play,
+/// Kalshi's milestone game stats, Polymarket's team metadata) live as inherent
+/// methods on the concrete provider type.
+#[allow(async_fn_in_trait)]
+pub trait SportsProvider: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn name(&self) -> &'static str;
+
+    /// Capability advertisement. Same pattern as `Exchange::describe()` —
+    /// callers branch on flags rather than catching `NotSupported` errors at
+    /// runtime.
+    fn capabilities(&self) -> SportsCapabilities;
+
+    /// Returns the provider's manifest containing the JSON-to-unified-schema
+    /// field map. Mirrors `Exchange::manifest()`.
+    fn manifest(&self) -> &'static SportsManifest;
+
+    /// List the sports this provider covers.
+    async fn list_sports(&self) -> Result<Vec<Sport>, OpenPxError>;
+
+    /// List games matching the filter. Returns `(games, next_cursor)`.
+    /// Pagination is opt-in: providers without a cursor return `None`.
+    async fn list_games(
+        &self,
+        filter: GameFilter,
+    ) -> Result<(Vec<Game>, Option<String>), OpenPxError>;
+
+    /// Fetch a single game by id. The `id` must be a `GameId` previously
+    /// returned by *this* provider.
+    async fn get_game(&self, id: &GameId) -> Result<Game, OpenPxError>;
+
+    /// Subscribe to live game-state updates. Implementations may use a
+    /// long-lived WebSocket (Polymarket) or HTTP polling (ESPN, Kalshi); the
+    /// stream contract is the same either way.
+    fn subscribe_game_state(&self) -> GameStateStream;
+}
+
+/// Static capability flags for a `SportsProvider`. Includes both parity-core
+/// methods (advertised because some providers can't honor them — e.g., Kalshi
+/// has no first-class team primitive) and the inherent ESPN-only extensions
+/// so callers can probe `capabilities().has_news` without downcasting.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SportsCapabilities {
+    pub id: &'static str,
+    pub name: &'static str,
+
+    // Parity-core
+    pub has_list_sports: bool,
+    pub has_list_games: bool,
+    pub has_get_game: bool,
+    pub has_live_state_stream: bool,
+
+    // Partial parity (some providers expose these as inherent methods)
+    pub has_teams: bool,
+    pub has_schedule: bool,
+    pub has_standings: bool,
+
+    // Provider-specific extensions
+    pub has_athletes: bool,
+    pub has_news: bool,
+    pub has_rankings: bool,
+    pub has_play_by_play: bool,
+}
+
+impl SportsCapabilities {
+    pub const fn none(id: &'static str, name: &'static str) -> Self {
+        Self {
+            id,
+            name,
+            has_list_sports: false,
+            has_list_games: false,
+            has_get_game: false,
+            has_live_state_stream: false,
+            has_teams: false,
+            has_schedule: false,
+            has_standings: false,
+            has_athletes: false,
+            has_news: false,
+            has_rankings: false,
+            has_play_by_play: false,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First PR in the sports data category reorg laid out in [the design plan](../). Purely **additive** — adds the unified schema and trait scaffolding without touching or moving any existing code. Single-purpose by design so the next 5 PRs in the series can each focus on one concrete impl.

The end state across all 6 PRs: ESPN joins as a sports research data provider, while Kalshi and Polymarket also implement the same `SportsProvider` trait from inside their existing exchange crates (no auth/HTTP duplication). The legacy `SportsWebSocket` (Polymarket-specific WS client currently in `engine/sports/src/lib.rs`) relocates to `engine/exchanges/polymarket/` in PR 2 alongside the first concrete impl.

## What landed

- **`engine/core/src/models/sports/`** — `Sport`, `League`, `Game`, `GameId`, `GameStatus`, `GameFilter`, `GameState`, `Score`. Modeled on the parity-core surface that exists in all three sources (ESPN scoreboard, Polymarket gamma `/teams` + sports market fields, Kalshi `/milestones` + `/live_data`). Unit `GameStatus` enum so manifest `status_map`s can be `&'static`. Raw provider status string preserved on `Game::raw_status` / `GameState::raw_status` for callers that need the un-normalized value.
- **`engine/sports/src/provider.rs`** — `SportsProvider` trait covering only the parity-core: `list_sports`, `list_games`, `get_game`, `subscribe_game_state`. Plus `SportsCapabilities` flag struct (same pattern as `Exchange::describe()`) advertising both parity-core support and provider-specific extensions.
- **`engine/sports/src/manifest.rs`** — `SportsManifest`, `FieldMapping`, `Transform`. Lighter than the exchange manifest (no rate-limit complexity, smaller `Transform` enum) but the same shape so the same drift-prevention test pattern can be wired in PR 2.
- **`schema` feature on `px-sports`** — gates `schemars::JsonSchema` derives so the schema export binary still works.

## Out of scope (intentionally — kept for follow-up PRs)

- Concrete provider impls for ESPN, Kalshi, Polymarket.
- Relocation of the existing `SportsWebSocket` Polymarket client.
- Extension of `maintenance/tests/manifest_coverage.rs` to cover sports manifests (lands in PR 2 with the first real provider manifest).
- Crypto reorg — same pattern, separate PR series after sports lands.
- SDK facade, Python/TS bindings, docs — bundled in PR 5.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test --workspace` — all existing tests pass; legacy `SportsWebSocket` tests unchanged.
- [x] `cargo check -p px-sports --features schema` — schema feature gate compiles.
- [x] `cargo check -p px-schema` — schema export binary still builds.

## Next PR

PR 2: Polymarket sports impl. Relocate `SportsWebSocket` to `engine/exchanges/polymarket/src/sports_ws.rs`, add `engine/exchanges/polymarket/src/sports.rs` with `impl SportsProvider for Polymarket`, and add `engine/sports/src/manifests/polymarket.rs` (the first manifest entry, which finally turns on the manifest_coverage gate for sports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)