### PR TITLE
refactor(core): trim manifest data layer

### DIFF
--- a/engine/core/src/exchange/manifest.rs
+++ b/engine/core/src/exchange/manifest.rs
@@ -1,79 +1,32 @@
-use crate::models::MarketStatus;
-
-/// Complete auditable manifest for an exchange.
-/// When opened, shows SOURCE and TRANSFORMATION side-by-side.
+/// Connection-level descriptor for an exchange.
+///
+/// Holds the data the rate limiter, fetcher, and HTTP layer query at runtime:
+/// base URL, markets endpoint, pagination shape, and rate-limit budgets.
+/// Field-level mapping into the unified `Market` is handled directly in each
+/// exchange's `parse_market()` — the manifest is not the contract for that.
 #[derive(Debug, Clone)]
 pub struct ExchangeManifest {
-    // ========================================
-    // SECTION 1: CONNECTION AUDIT (Where do we go?)
-    // ========================================
-    /// Exchange identifier (e.g., "kalshi", "polymarket")
     pub id: &'static str,
-
-    /// Human-readable exchange name
     pub name: &'static str,
-
-    /// Base API URL
     pub base_url: &'static str,
-
-    /// Markets list endpoint (relative to base_url)
     pub markets_endpoint: &'static str,
-
-    /// Pagination configuration
     pub pagination: PaginationConfig,
-
-    /// Rate limiting configuration
     pub rate_limit: RateLimitConfig,
-
-    // ========================================
-    // SECTION 2: DATA AUDIT (How do we map it?)
-    // ========================================
-    /// Field mappings from raw exchange JSON to Market
-    pub field_mappings: &'static [FieldMapping],
-
-    /// Status value mappings (exchange status -> MarketStatus)
-    pub status_map: &'static [(&'static str, MarketStatus)],
-}
-
-impl ExchangeManifest {
-    /// Look up the MarketStatus for a given exchange status string.
-    /// Status map entries should be lowercase at definition time for O(n) without allocation.
-    pub fn map_status(&self, exchange_status: &str) -> Option<MarketStatus> {
-        self.status_map
-            .iter()
-            .find(|(s, _)| s.eq_ignore_ascii_case(exchange_status))
-            .map(|(_, status)| *status)
-    }
-
-    /// Get a field mapping by unified field name.
-    pub fn get_field_mapping(&self, unified_field: &str) -> Option<&FieldMapping> {
-        self.field_mappings
-            .iter()
-            .find(|m| m.unified_field == unified_field)
-    }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct PaginationConfig {
-    /// Pagination style: Cursor, Offset, Page
     pub style: PaginationStyle,
-    /// Maximum items per page
     pub max_page_size: usize,
-    /// Query param name for limit
     pub limit_param: &'static str,
-    /// Query param name for cursor/offset
     pub cursor_param: &'static str,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PaginationStyle {
-    /// Cursor-based pagination (Kalshi)
     Cursor,
-    /// Offset-based pagination (Polymarket)
     Offset,
-    /// Page-number pagination (1-indexed)
     PageNumber,
-    /// No pagination supported - endpoint returns all data in single call
     None,
 }
 
@@ -99,7 +52,6 @@ impl RateLimitCategory {
     ];
 }
 
-/// Rate limit for a single endpoint category.
 #[derive(Debug, Clone, Copy)]
 pub struct EndpointRateLimit {
     pub category: RateLimitCategory,
@@ -111,16 +63,12 @@ pub struct EndpointRateLimit {
 /// Categories not listed in `limits` inherit from `default_rps`/`default_burst`.
 #[derive(Debug, Clone, Copy)]
 pub struct RateLimitConfig {
-    /// Fallback rate for any category not explicitly listed.
     pub default_rps: u32,
-    /// Default burst for any category not explicitly listed.
     pub default_burst: u32,
-    /// Per-category overrides (searched linearly; at most 3 entries).
     pub limits: &'static [EndpointRateLimit],
 }
 
 impl RateLimitConfig {
-    /// Look up (rps, burst) for a given category.
     pub const fn get(&self, category: RateLimitCategory) -> (u32, u32) {
         let mut i = 0;
         while i < self.limits.len() {
@@ -132,49 +80,11 @@ impl RateLimitConfig {
         (self.default_rps, self.default_burst)
     }
 
-    /// Convenience: get requests_per_second for a category.
     pub const fn rps(&self, category: RateLimitCategory) -> u32 {
         self.get(category).0
     }
 
-    /// Backwards-compat: overall requests_per_second (uses Read category).
     pub const fn requests_per_second(&self) -> u32 {
         self.default_rps
     }
-}
-
-/// Mapping from raw exchange JSON field to unified field.
-#[derive(Debug, Clone)]
-pub struct FieldMapping {
-    /// Target field in Market
-    pub unified_field: &'static str,
-    /// Source path(s) in raw JSON (fallback chain)
-    pub source_paths: &'static [&'static str],
-    /// Transformation to apply
-    pub transform: Transform,
-    /// Whether field can be null
-    pub nullable: bool,
-}
-
-/// Transformation to apply when mapping a field.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Transform {
-    /// No transformation - use value directly
-    Direct,
-    /// Divide by 100 (Kalshi prices: cents -> decimal)
-    CentsToDollars,
-    /// Unix timestamp (seconds) to DateTime
-    UnixSecsToDateTime,
-    /// Unix timestamp (milliseconds) to DateTime
-    UnixMillisToDateTime,
-    /// ISO8601 string to DateTime
-    Iso8601ToDateTime,
-    /// String/Float -> i64
-    ParseInt,
-    /// String -> f64
-    ParseFloat,
-    /// Extract element at index from JSON array
-    JsonArrayIndex(usize),
-    /// Nested path extraction (dot-notation handled by source_paths)
-    NestedPath,
 }

--- a/engine/core/src/exchange/manifests/kalshi.rs
+++ b/engine/core/src/exchange/manifests/kalshi.rs
@@ -1,11 +1,9 @@
 use crate::exchange::manifest::{
-    EndpointRateLimit, ExchangeManifest, FieldMapping, PaginationConfig, PaginationStyle,
-    RateLimitCategory, RateLimitConfig, Transform,
+    EndpointRateLimit, ExchangeManifest, PaginationConfig, PaginationStyle, RateLimitCategory,
+    RateLimitConfig,
 };
-use crate::models::MarketStatus;
 
 pub const KALSHI_MANIFEST: ExchangeManifest = ExchangeManifest {
-    // ====== CONNECTION AUDIT ======
     id: "kalshi",
     name: "Kalshi",
     base_url: "https://api.elections.kalshi.com/trade-api/v2",
@@ -32,102 +30,4 @@ pub const KALSHI_MANIFEST: ExchangeManifest = ExchangeManifest {
             },
         ],
     },
-
-    // ====== DATA AUDIT ======
-    field_mappings: &[
-        FieldMapping {
-            unified_field: "id",
-            source_paths: &["ticker"],
-            transform: Transform::Direct,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "title",
-            source_paths: &["title"],
-            transform: Transform::Direct,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "question",
-            source_paths: &["title"],
-            transform: Transform::Direct,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "description",
-            source_paths: &["rules_primary"],
-            transform: Transform::Direct,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "volume",
-            source_paths: &["volume_fp", "volume"],
-            transform: Transform::ParseFloat,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "open_interest",
-            source_paths: &["open_interest_fp", "open_interest"],
-            transform: Transform::ParseFloat,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "close_time",
-            source_paths: &["close_time"],
-            transform: Transform::Iso8601ToDateTime,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "open_time",
-            source_paths: &["open_time"],
-            transform: Transform::Iso8601ToDateTime,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "group_id",
-            source_paths: &["event_ticker"],
-            transform: Transform::Direct,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "slug",
-            source_paths: &["subtitle"],
-            transform: Transform::Direct,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "market_type",
-            source_paths: &["market_type"],
-            transform: Transform::Direct,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "condition_id",
-            source_paths: &[],
-            transform: Transform::Direct,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "token_id_yes",
-            source_paths: &[],
-            transform: Transform::Direct,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "token_id_no",
-            source_paths: &[],
-            transform: Transform::Direct,
-            nullable: true,
-        },
-    ],
-    status_map: &[
-        ("active", MarketStatus::Active),
-        ("closed", MarketStatus::Closed),
-        ("determined", MarketStatus::Resolved),
-        ("finalized", MarketStatus::Resolved),
-        ("initialized", MarketStatus::Closed),
-        ("inactive", MarketStatus::Closed),
-        ("disputed", MarketStatus::Closed),
-        ("amended", MarketStatus::Closed),
-    ],
 };

--- a/engine/core/src/exchange/manifests/polymarket.rs
+++ b/engine/core/src/exchange/manifests/polymarket.rs
@@ -1,10 +1,9 @@
 use crate::exchange::manifest::{
-    EndpointRateLimit, ExchangeManifest, FieldMapping, PaginationConfig, PaginationStyle,
-    RateLimitCategory, RateLimitConfig, Transform,
+    EndpointRateLimit, ExchangeManifest, PaginationConfig, PaginationStyle, RateLimitCategory,
+    RateLimitConfig,
 };
 
 pub const POLYMARKET_MANIFEST: ExchangeManifest = ExchangeManifest {
-    // ====== CONNECTION AUDIT ======
     id: "polymarket",
     name: "Polymarket",
     base_url: "https://gamma-api.polymarket.com",
@@ -31,94 +30,4 @@ pub const POLYMARKET_MANIFEST: ExchangeManifest = ExchangeManifest {
             },
         ],
     },
-
-    // ====== DATA AUDIT ======
-    field_mappings: &[
-        FieldMapping {
-            unified_field: "id",
-            source_paths: &["id"],
-            transform: Transform::Direct,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "title",
-            source_paths: &["question"],
-            transform: Transform::Direct,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "question",
-            source_paths: &["question"],
-            transform: Transform::Direct,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "description",
-            source_paths: &["description"],
-            transform: Transform::Direct,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "volume",
-            source_paths: &["volumeNum", "volume"],
-            transform: Transform::ParseInt,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "liquidity",
-            source_paths: &["liquidityNum", "liquidity"],
-            transform: Transform::ParseInt,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "close_time",
-            source_paths: &["endDate"],
-            transform: Transform::Iso8601ToDateTime,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "open_time",
-            source_paths: &["startDate"],
-            transform: Transform::Iso8601ToDateTime,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "group_id",
-            source_paths: &["events.0.id"],
-            transform: Transform::NestedPath,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "slug",
-            source_paths: &["slug"],
-            transform: Transform::Direct,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "market_type",
-            source_paths: &["marketType"],
-            transform: Transform::Direct,
-            nullable: false,
-        },
-        FieldMapping {
-            unified_field: "condition_id",
-            source_paths: &["conditionId"],
-            transform: Transform::Direct,
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "token_id_yes",
-            source_paths: &["clobTokenIds.0"],
-            transform: Transform::JsonArrayIndex(0),
-            nullable: true,
-        },
-        FieldMapping {
-            unified_field: "token_id_no",
-            source_paths: &["clobTokenIds.1"],
-            transform: Transform::JsonArrayIndex(1),
-            nullable: true,
-        },
-    ],
-    // Polymarket uses boolean flags, handled specially in the adapter
-    status_map: &[],
 };

--- a/engine/core/src/exchange/normalizers.rs
+++ b/engine/core/src/exchange/normalizers.rs
@@ -1,19 +1,15 @@
 use chrono::{DateTime, Utc};
 use serde_json::Value;
 
-use crate::exchange::manifest::Transform;
-
 /// Safe type coercion to i64 with null fallback (never panic).
 pub fn coerce_to_int(value: &Value) -> Option<i64> {
     match value {
         Value::Number(n) => n.as_i64().or_else(|| n.as_f64().map(|f| f as i64)),
-        Value::String(s) => {
-            // Try parsing as integer first, then as float
-            s.trim()
-                .parse::<i64>()
-                .ok()
-                .or_else(|| s.trim().parse::<f64>().ok().map(|f| f as i64))
-        }
+        Value::String(s) => s
+            .trim()
+            .parse::<i64>()
+            .ok()
+            .or_else(|| s.trim().parse::<f64>().ok().map(|f| f as i64)),
         Value::Bool(b) => Some(if *b { 1 } else { 0 }),
         _ => None,
     }
@@ -39,37 +35,35 @@ pub fn coerce_to_string(value: &Value) -> Option<String> {
     }
 }
 
-/// Convert a value to DateTime based on the transform type.
-pub fn coerce_to_datetime(value: &Value, transform: Transform) -> Option<DateTime<Utc>> {
-    match transform {
-        Transform::Iso8601ToDateTime => {
-            let s = value.as_str()?;
-            // Try RFC3339 first
-            DateTime::parse_from_rfc3339(s)
+/// Parse an ISO8601 / RFC3339 string into `DateTime<Utc>`.
+/// Falls back through a few common variants seen in the wild.
+pub fn coerce_iso8601_datetime(value: &Value) -> Option<DateTime<Utc>> {
+    let s = value.as_str()?;
+    DateTime::parse_from_rfc3339(s)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+        .or_else(|| {
+            chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
                 .ok()
-                .map(|dt| dt.with_timezone(&Utc))
-                .or_else(|| {
-                    // Try other common formats
-                    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f")
-                        .ok()
-                        .map(|ndt| ndt.and_utc())
-                })
-                .or_else(|| {
-                    chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
-                        .ok()
-                        .map(|ndt| ndt.and_utc())
-                })
-        }
-        Transform::UnixSecsToDateTime => {
-            let ts = coerce_to_int(value)?;
-            DateTime::from_timestamp(ts, 0)
-        }
-        Transform::UnixMillisToDateTime => {
-            let ts = coerce_to_int(value)?;
-            DateTime::from_timestamp_millis(ts)
-        }
-        _ => None,
-    }
+                .map(|ndt| ndt.and_utc())
+        })
+        .or_else(|| {
+            chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S")
+                .ok()
+                .map(|ndt| ndt.and_utc())
+        })
+}
+
+/// Parse a Unix-seconds integer into `DateTime<Utc>`.
+pub fn coerce_unix_secs_datetime(value: &Value) -> Option<DateTime<Utc>> {
+    let ts = coerce_to_int(value)?;
+    DateTime::from_timestamp(ts, 0)
+}
+
+/// Parse a Unix-milliseconds integer into `DateTime<Utc>`.
+pub fn coerce_unix_millis_datetime(value: &Value) -> Option<DateTime<Utc>> {
+    let ts = coerce_to_int(value)?;
+    DateTime::from_timestamp_millis(ts)
 }
 
 /// Extract value from JSON using a dot-notation path.
@@ -82,10 +76,8 @@ pub fn get_nested<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
     let mut current = value;
     for part in path.split('.') {
         current = if let Ok(index) = part.parse::<usize>() {
-            // Array index
             current.get(index)?
         } else {
-            // Object key
             current.get(part)?
         };
     }
@@ -141,24 +133,24 @@ mod tests {
     }
 
     #[test]
-    fn test_coerce_to_datetime_iso8601() {
+    fn test_coerce_iso8601_datetime() {
         let value = json!("2024-12-31T23:59:59Z");
-        let dt = coerce_to_datetime(&value, Transform::Iso8601ToDateTime);
+        let dt = coerce_iso8601_datetime(&value);
         assert!(dt.is_some());
         assert_eq!(dt.unwrap().year(), 2024);
     }
 
     #[test]
-    fn test_coerce_to_datetime_unix_secs() {
-        let value = json!(1704067199); // 2023-12-31T23:59:59Z
-        let dt = coerce_to_datetime(&value, Transform::UnixSecsToDateTime);
+    fn test_coerce_unix_secs_datetime() {
+        let value = json!(1704067199);
+        let dt = coerce_unix_secs_datetime(&value);
         assert!(dt.is_some());
     }
 
     #[test]
-    fn test_coerce_to_datetime_unix_millis() {
+    fn test_coerce_unix_millis_datetime() {
         let value = json!(1704067199000_i64);
-        let dt = coerce_to_datetime(&value, Transform::UnixMillisToDateTime);
+        let dt = coerce_unix_millis_datetime(&value);
         assert!(dt.is_some());
     }
 }


### PR DESCRIPTION
## Summary

- Drops `field_mappings` and `status_map` from `ExchangeManifest`. Removes the `FieldMapping` struct, the `Transform` enum, and the `map_status` / `get_field_mapping` methods. The `MarketStatus` import is no longer needed.
- The manifest now describes only what runtime callers actually query: `id`, `name`, `base_url`, `markets_endpoint`, `pagination`, `rate_limit`. Per-exchange `parse_market()` becomes the contract for unified `Market` mapping (it was already doing ~37 of the ~50 fields).
- `engine/core/src/exchange/normalizers.rs`: `coerce_to_datetime(value, Transform)` is replaced by three explicit free functions (`coerce_iso8601_datetime`, `coerce_unix_secs_datetime`, `coerce_unix_millis_datetime`). No callers outside this file's tests/benches.

## Why

The data layer covered ~13 of ~50 `Market` fields; the rest were hand-parsed. The manifest looked authoritative but wasn't — readers had to check both the manifest and the parser. Backfilling to 50 fields would have required growing `Transform` for every irregular case (JSON-stringified arrays, boolean-derived status, computed fees), which has core-side enum blast radius. Hand-parsing is what the codebase was already doing in practice.

A competitor unified-prediction-markets repo (`pmxt`, 8 exchanges) uses the same discipline — vendored upstream specs + hand-written `normalizer.ts` per exchange, no field-mapping manifest. Validates the approach at scale.

## Scope

- No exchange-implementation changes. `parse_market()` for both Kalshi and Polymarket is unchanged in this PR.
- No SDK or schema changes (the unified `Market` struct is untouched).
- 4 files: `engine/core/src/exchange/manifest.rs`, `engine/core/src/exchange/manifests/{kalshi,polymarket}.rs`, `engine/core/src/exchange/normalizers.rs`. Net −289 lines.

## Stacked PR

`feat/polymarket-keyset-migration` (the Polymarket `/markets/keyset` migration) is stacked on top of this branch.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p px-core` (58/58 passing)
- [x] `cargo test --workspace` (all suites green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)