### PR TITLE
feat(polymarket): migrate fetch_markets to /markets/keyset

### DIFF
--- a/engine/core/src/exchange/manifests/polymarket.rs
+++ b/engine/core/src/exchange/manifests/polymarket.rs
@@ -7,12 +7,12 @@ pub const POLYMARKET_MANIFEST: ExchangeManifest = ExchangeManifest {
     id: "polymarket",
     name: "Polymarket",
     base_url: "https://gamma-api.polymarket.com",
-    markets_endpoint: "/markets",
+    markets_endpoint: "/markets/keyset",
     pagination: PaginationConfig {
-        style: PaginationStyle::Offset,
-        max_page_size: 500,
+        style: PaginationStyle::Cursor,
+        max_page_size: 1000,
         limit_param: "limit",
-        cursor_param: "offset",
+        cursor_param: "after_cursor",
     },
     rate_limit: RateLimitConfig {
         default_rps: 150,

--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -91,6 +91,19 @@ struct SdkState {
 }
 
 /// Parse CLOB `/orderbook-history` response data into `OrderbookSnapshot`s.
+/// Decide whether a market with the given status should be included given the
+/// caller's filter. Polymarket has no native "Resolved" — `closed=true` covers
+/// both Closed and Resolved on our side, so they are aliases here.
+fn status_matches_filter(status: MarketStatus, filter: MarketStatusFilter) -> bool {
+    match filter {
+        MarketStatusFilter::All => true,
+        MarketStatusFilter::Active => status == MarketStatus::Active,
+        MarketStatusFilter::Closed | MarketStatusFilter::Resolved => {
+            matches!(status, MarketStatus::Closed | MarketStatus::Resolved)
+        }
+    }
+}
+
 fn parse_orderbook_snapshots(data: &serde_json::Value) -> Vec<OrderbookSnapshot> {
     let history = data
         .get("data")
@@ -1251,8 +1264,19 @@ impl Polymarket {
             icon_url: parse_str(obj, "icon"),
             neg_risk: obj.get("negRisk").and_then(|v| v.as_bool()),
             neg_risk_market_id: parse_str(obj, "negRiskMarketID"),
-            maker_fee_bps: parse_f64(obj, "makerBaseFee"),
-            taker_fee_bps: parse_f64(obj, "takerBaseFee"),
+            // 2026-03-31: fees should now be sourced from `feeSchedule.rate`
+            // (the legacy `makerBaseFee`/`takerBaseFee` flat fields are kept
+            // as fallback for older payloads).
+            maker_fee_bps: obj
+                .get("feeSchedule")
+                .and_then(|fs| fs.get("rate"))
+                .and_then(|v| v.as_f64())
+                .or_else(|| parse_f64(obj, "makerBaseFee")),
+            taker_fee_bps: obj
+                .get("feeSchedule")
+                .and_then(|fs| fs.get("rate"))
+                .and_then(|v| v.as_f64())
+                .or_else(|| parse_f64(obj, "takerBaseFee")),
             denomination_token: parse_str(obj, "denominationToken"),
             ..Default::default()
         })
@@ -1691,9 +1715,8 @@ impl Exchange for Polymarket {
         &self,
         params: &FetchMarketsParams,
     ) -> Result<(Vec<Market>, Option<String>), OpenPxError> {
-        // ── event_id short-circuit: fetch a single event's nested markets ──
+        // event_id short-circuit: a single event's nested markets, no pagination.
         if let Some(ref eid) = params.event_id {
-            // Numeric → /events/{id}, otherwise → /events/slug/{slug}
             let endpoint = if eid.chars().all(|c| c.is_ascii_digit()) {
                 format!("/events/{eid}")
             } else {
@@ -1720,20 +1743,8 @@ impl Exchange for Polymarket {
                 for market_raw in market_array {
                     let raw = market_raw.clone();
                     if let Some(mut parsed) = self.parse_market(raw) {
-                        if filter != MarketStatusFilter::All {
-                            let status_matches = match filter {
-                                MarketStatusFilter::Active => parsed.status == MarketStatus::Active,
-                                MarketStatusFilter::Closed | MarketStatusFilter::Resolved => {
-                                    matches!(
-                                        parsed.status,
-                                        MarketStatus::Closed | MarketStatus::Resolved
-                                    )
-                                }
-                                MarketStatusFilter::All => unreachable!(),
-                            };
-                            if !status_matches {
-                                continue;
-                            }
+                        if !status_matches_filter(parsed.status, filter) {
+                            continue;
                         }
                         if parsed.group_id.is_none() {
                             parsed.group_id = Some(native_event_id.clone());
@@ -1749,93 +1760,131 @@ impl Exchange for Polymarket {
             return Ok((markets, None));
         }
 
-        // Polymarket events use boolean query params. The events endpoint
-        // filters at the event level, so we need closed=false to avoid
-        // getting events whose markets are all closed.
-        // Polymarket has no separate "resolved" state — closed=true means settled.
-        let status_param = match params.status {
-            Some(MarketStatusFilter::Active) | None => Some("active=true&closed=false"),
-            Some(MarketStatusFilter::Closed) | Some(MarketStatusFilter::Resolved) => {
-                Some("closed=true")
+        // /markets/keyset is cursor-paginated and replaces the offset-based
+        // /markets and the /events-fanout we used to call. /events/keyset is
+        // routed through only when the caller asks for series-level grouping
+        // (which /markets/keyset does not filter by).
+        //
+        // Polymarket has no native "All" — it has a single `closed` boolean.
+        // So `MarketStatusFilter::All` is implemented as a sequential two-phase
+        // drain (closed=false → closed=true) using a compound JSON cursor:
+        //   {"p":"o","c":<after_cursor>}  while draining closed=false
+        //   {"p":"c","c":<after_cursor>}  after the open phase exhausts
+        // Non-All filters use the raw `next_cursor` string verbatim.
+        #[derive(serde::Serialize, serde::Deserialize)]
+        struct AllCursor {
+            p: String,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            c: Option<String>,
+        }
+
+        let limit = params.limit.unwrap_or(500).min(1000);
+        let filter = params.status.unwrap_or(MarketStatusFilter::Active);
+
+        let (phase, after_cursor): (&'static str, Option<String>) = match filter {
+            MarketStatusFilter::Active => ("o", params.cursor.clone()),
+            MarketStatusFilter::Closed | MarketStatusFilter::Resolved => {
+                ("c", params.cursor.clone())
             }
-            Some(MarketStatusFilter::All) => None,
+            MarketStatusFilter::All => match params.cursor.as_deref() {
+                None => ("o", None),
+                Some(s) => match serde_json::from_str::<AllCursor>(s) {
+                    Ok(st) if st.p == "c" => ("c", st.c),
+                    Ok(st) => ("o", st.c),
+                    Err(_) => ("o", None),
+                },
+            },
         };
+        let closed_val = phase == "c";
 
-        let offset = params
-            .cursor
-            .as_ref()
-            .and_then(|c| c.parse::<usize>().ok())
-            .unwrap_or(0);
-
-        let mut endpoint = match status_param {
-            Some(sp) => format!("/events?limit=200&{sp}&offset={offset}"),
-            None => format!("/events?limit=200&offset={offset}"),
+        let mut endpoint = if let Some(ref sid) = params.series_id {
+            format!("/events/keyset?series_id={sid}&limit={limit}&closed={closed_val}")
+        } else {
+            format!("/markets/keyset?limit={limit}&closed={closed_val}")
         };
-        if let Some(ref sid) = params.series_id {
-            endpoint.push_str(&format!("&series_id={sid}"));
+        if let Some(ref ac) = after_cursor {
+            if !ac.is_empty() {
+                endpoint.push_str(&format!("&after_cursor={ac}"));
+            }
         }
 
         self.rate_limit().await;
 
-        let events: Vec<serde_json::Value> = self
+        let resp: serde_json::Value = self
             .client
             .get_gamma(&endpoint)
             .await
             .map_err(|e| OpenPxError::Exchange(e.into()))?;
 
-        let events_len = events.len();
-        let mut markets = Vec::new();
+        let next_cursor_raw = resp
+            .get("next_cursor")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(String::from);
 
-        for event in events {
-            let native_event_id = event
-                .get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or_default()
-                .to_string();
-
-            let Some(market_array) = event.get("markets").and_then(|v| v.as_array()) else {
-                continue;
-            };
-
-            let filter = params.status.unwrap_or(MarketStatusFilter::Active);
-
-            for market_raw in market_array {
-                let raw = market_raw.clone();
-                if let Some(mut parsed) = self.parse_market(raw) {
-                    // Events can contain markets with mixed statuses — filter to
-                    // only return markets matching the requested status.
-                    // Polymarket has no separate "closed" vs "resolved" state, so
-                    // accept Resolved for both Closed and Resolved requests.
-                    if filter != MarketStatusFilter::All {
-                        let status_matches = match filter {
-                            MarketStatusFilter::Active => parsed.status == MarketStatus::Active,
-                            MarketStatusFilter::Closed | MarketStatusFilter::Resolved => {
-                                matches!(
-                                    parsed.status,
-                                    MarketStatus::Closed | MarketStatus::Resolved
-                                )
+        let mut markets: Vec<Market> = Vec::new();
+        if params.series_id.is_some() {
+            // /events/keyset returns {events:[{id, markets:[...]}], next_cursor}
+            let events = resp.get("events").and_then(|v| v.as_array());
+            if let Some(events) = events {
+                for event in events {
+                    let native_event_id = event
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let Some(market_array) = event.get("markets").and_then(|v| v.as_array()) else {
+                        continue;
+                    };
+                    for market_raw in market_array {
+                        if let Some(mut parsed) = self.parse_market(market_raw.clone()) {
+                            if !status_matches_filter(parsed.status, filter) {
+                                continue;
                             }
-                            MarketStatusFilter::All => unreachable!(),
-                        };
-                        if !status_matches {
-                            continue;
+                            if parsed.group_id.is_none() {
+                                parsed.group_id = Some(native_event_id.clone());
+                            }
+                            if parsed.event_id.is_none() {
+                                parsed.event_id =
+                                    canonical_event_id("polymarket", &native_event_id);
+                            }
+                            markets.push(parsed);
                         }
                     }
-                    if parsed.group_id.is_none() {
-                        parsed.group_id = Some(native_event_id.clone());
+                }
+            }
+        } else {
+            // /markets/keyset returns {markets:[...], next_cursor}
+            if let Some(arr) = resp.get("markets").and_then(|v| v.as_array()) {
+                for market_raw in arr {
+                    if let Some(parsed) = self.parse_market(market_raw.clone()) {
+                        if !status_matches_filter(parsed.status, filter) {
+                            continue;
+                        }
+                        markets.push(parsed);
                     }
-                    if parsed.event_id.is_none() {
-                        parsed.event_id = canonical_event_id("polymarket", &native_event_id);
-                    }
-                    markets.push(parsed);
                 }
             }
         }
 
-        let next_cursor = if events_len == 200 {
-            Some((offset + events_len).to_string())
-        } else {
-            None
+        let next_cursor = match filter {
+            MarketStatusFilter::Active
+            | MarketStatusFilter::Closed
+            | MarketStatusFilter::Resolved => next_cursor_raw,
+            MarketStatusFilter::All => {
+                let (next_phase, next_after) = match (phase, next_cursor_raw) {
+                    ("o", Some(c)) => ("o", Some(c)),
+                    ("o", None) => ("c", None), // transition: open exhausted, start closed
+                    ("c", Some(c)) => ("c", Some(c)),
+                    ("c", None) => return Ok((markets, None)),
+                    _ => return Ok((markets, None)),
+                };
+                serde_json::to_string(&AllCursor {
+                    p: next_phase.into(),
+                    c: next_after,
+                })
+                .ok()
+            }
         };
 
         info!(total = markets.len(), "polymarket fetch_markets completed");

--- a/engine/exchanges/polymarket/src/fetcher.rs
+++ b/engine/exchanges/polymarket/src/fetcher.rs
@@ -1,30 +1,40 @@
-use futures::stream::{FuturesUnordered, StreamExt};
 use px_core::{
     manifests::POLYMARKET_MANIFEST, CheckpointCallback, FetchResult, MarketFetcher, OpenPxError,
 };
 use reqwest::Client;
-use std::collections::BTreeMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::time::Duration;
-use tokio::sync::Semaphore;
 use tracing::info;
 
 use crate::error::PolymarketError;
 
-/// Number of concurrent requests to maintain for optimal throughput.
-/// With ~300-500ms latency and 30 req/s limit, we need ~15 concurrent requests.
-const CONCURRENCY: usize = 15;
+/// /markets/keyset is cursor-paginated, so we can't fan out within a single
+/// stream. Two-phase drain — `closed=false` then `closed=true` — gives us the
+/// only natural parallelism axis Polymarket exposes for "all markets".
+const PHASES: &[(bool, &str)] = &[(false, "o"), (true, "c")];
 
-/// Type alias for boxed fetch future (stream_id, offset, markets)
-type FetchFuture = Pin<
-    Box<dyn Future<Output = Result<(usize, usize, Vec<serde_json::Value>), OpenPxError>> + Send>,
->;
+/// Per-phase cursor state for resumable bulk fetches. Serialized as the
+/// fetcher's compound cursor string.
+/// - Key absent  → phase not yet started (begin from no cursor).
+/// - Value `None` → phase exhausted.
+/// - Value `Some(_)` → continue from that `after_cursor`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct PhaseCursors {
+    cursors: HashMap<String, Option<String>>,
+}
 
-/// Market fetcher for Polymarket Bronze layer ingestion.
-/// Uses the Gamma API for public market data with concurrent fetching.
+impl PhaseCursors {
+    fn parse(s: Option<&str>) -> Self {
+        s.and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default()
+    }
+
+    fn serialize(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+}
+
 pub struct PolymarketMarketFetcher {
     base_url: String,
 }
@@ -36,32 +46,31 @@ impl PolymarketMarketFetcher {
         })
     }
 
-    /// Create a new HTTP client for fetching.
-    /// Uses the shared `px_core::http::tuned_client_builder()` and then
-    /// overrides `pool_max_idle_per_host` to match our CONCURRENCY (15),
-    /// since the fetcher opens more parallel streams than normal REST.
     fn create_client() -> Result<Client, PolymarketError> {
         px_core::http::tuned_client_builder()
-            .pool_max_idle_per_host(CONCURRENCY)
+            .pool_max_idle_per_host(PHASES.len())
             .timeout(Duration::from_secs(30))
             .build()
             .map_err(PolymarketError::from)
     }
 
-    /// Fetch a single page of markets.
-    async fn fetch_page(
-        client: Client,
-        base_url: String,
-        offset: usize,
+    /// Fetch one keyset page for a given phase.
+    /// Returns (markets, next_cursor). `next_cursor` is `None` when the phase
+    /// is exhausted (server omits or empties the field).
+    async fn fetch_phase_page(
+        client: &Client,
+        base_url: &str,
+        closed: bool,
+        after_cursor: Option<&str>,
         page_size: usize,
-        stream_id: usize,
-    ) -> Result<(usize, usize, Vec<serde_json::Value>), OpenPxError> {
-        info!(
-            exchange = "polymarket",
-            stream_id, offset, "Stream fetching page"
+    ) -> Result<(Vec<serde_json::Value>, Option<String>), OpenPxError> {
+        let mut url = format!(
+            "{}/markets/keyset?limit={}&closed={}",
+            base_url, page_size, closed
         );
-
-        let url = format!("{}/markets?limit={}&offset={}", base_url, page_size, offset);
+        if let Some(c) = after_cursor.filter(|s| !s.is_empty()) {
+            url.push_str(&format!("&after_cursor={c}"));
+        }
 
         let response = client
             .get(&url)
@@ -75,34 +84,22 @@ impl PolymarketMarketFetcher {
             return Err(OpenPxError::Exchange(PolymarketError::Api(body).into()));
         }
 
-        let markets: Vec<serde_json::Value> = response
+        let mut body: serde_json::Value = response
             .json()
             .await
             .map_err(|e| OpenPxError::Exchange(PolymarketError::from(e).into()))?;
 
-        Ok((stream_id, offset, markets))
-    }
+        let markets = match body.get_mut("markets").map(serde_json::Value::take) {
+            Some(serde_json::Value::Array(arr)) => arr,
+            _ => Vec::new(),
+        };
+        let next_cursor = body
+            .get("next_cursor")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(String::from);
 
-    /// Create a fetch task that respects the semaphore and done flag.
-    fn create_fetch_task(
-        client: Client,
-        base_url: String,
-        offset: usize,
-        page_size: usize,
-        semaphore: Arc<Semaphore>,
-        done: Arc<AtomicBool>,
-        stream_id: usize,
-    ) -> FetchFuture {
-        Box::pin(async move {
-            let _permit = semaphore
-                .acquire()
-                .await
-                .map_err(|_| px_core::OpenPxError::Other("semaphore closed".into()))?;
-            if done.load(Ordering::SeqCst) {
-                return Ok((stream_id, offset, vec![]));
-            }
-            Self::fetch_page(client, base_url, offset, page_size, stream_id).await
-        })
+        Ok((markets, next_cursor))
     }
 }
 
@@ -115,84 +112,41 @@ impl MarketFetcher for PolymarketMarketFetcher {
         let client = Self::create_client().map_err(|e| OpenPxError::Exchange(e.into()))?;
         let max_page_size = POLYMARKET_MANIFEST.pagination.max_page_size;
 
-        // Shared state for concurrent fetching
-        let next_offset = Arc::new(AtomicUsize::new(0));
-        let done = Arc::new(AtomicBool::new(false));
-        let semaphore = Arc::new(Semaphore::new(CONCURRENCY));
+        let mut all_markets = Vec::new();
 
-        // Results stored by offset for ordering
-        let mut results: BTreeMap<usize, Vec<serde_json::Value>> = BTreeMap::new();
-        let mut futures: FuturesUnordered<FetchFuture> = FuturesUnordered::new();
-
-        // Start initial batch of concurrent requests
-        for stream_id in 0..CONCURRENCY {
-            let offset = next_offset.fetch_add(max_page_size, Ordering::SeqCst);
-            futures.push(Self::create_fetch_task(
-                client.clone(),
-                self.base_url.clone(),
-                offset,
-                max_page_size,
-                Arc::clone(&semaphore),
-                Arc::clone(&done),
-                stream_id,
-            ));
-        }
-
-        let mut total_fetched = 0;
-        let mut highest_complete_offset = 0;
-
-        while let Some(result) = futures.next().await {
-            let (stream_id, offset, markets) = result?;
-            let count = markets.len();
-
-            if count > 0 {
-                results.insert(offset, markets);
-                total_fetched += count;
-            }
-
-            // Check if this page signals end of data
-            if count < max_page_size {
-                done.store(true, Ordering::SeqCst);
-            }
-
-            // Queue next request if not done (reuse stream_id)
-            if !done.load(Ordering::SeqCst) {
-                let next = next_offset.fetch_add(max_page_size, Ordering::SeqCst);
-                futures.push(Self::create_fetch_task(
-                    client.clone(),
-                    self.base_url.clone(),
-                    next,
+        for &(closed, label) in PHASES {
+            let mut after: Option<String> = None;
+            let mut iteration = 0;
+            loop {
+                let (mut markets, next) = Self::fetch_phase_page(
+                    &client,
+                    &self.base_url,
+                    closed,
+                    after.as_deref(),
                     max_page_size,
-                    Arc::clone(&semaphore),
-                    Arc::clone(&done),
-                    stream_id,
-                ));
-            }
+                )
+                .await?;
 
-            // Log progress periodically
-            while results.contains_key(&highest_complete_offset) {
-                let page_count = results
-                    .get(&highest_complete_offset)
-                    .map(|v| v.len())
-                    .unwrap_or(0);
+                let count = markets.len();
+                all_markets.append(&mut markets);
+
                 info!(
                     exchange = "polymarket",
-                    offset = highest_complete_offset,
-                    page_count,
-                    total = total_fetched,
+                    phase = label,
+                    iteration,
+                    page_count = count,
+                    total = all_markets.len(),
                     "Fetched page"
                 );
-                highest_complete_offset += max_page_size;
+
+                iteration += 1;
+                after = next;
+                if after.is_none() {
+                    break;
+                }
             }
         }
 
-        // Collect results in order
-        let mut all_markets = Vec::with_capacity(total_fetched);
-        for (_, markets) in results {
-            all_markets.extend(markets);
-        }
-
-        // Client is dropped here, closing connections
         drop(client);
 
         Ok(all_markets)
@@ -218,108 +172,67 @@ impl MarketFetcher for PolymarketMarketFetcher {
         let client = Self::create_client().map_err(|e| OpenPxError::Exchange(e.into()))?;
         let max_page_size = POLYMARKET_MANIFEST.pagination.max_page_size;
 
-        // Parse start offset from cursor
-        let start_offset: usize = start_cursor
-            .as_ref()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        // Shared state for concurrent fetching
-        let next_offset = Arc::new(AtomicUsize::new(start_offset));
-        let done = Arc::new(AtomicBool::new(false));
-        let semaphore = Arc::new(Semaphore::new(CONCURRENCY));
-
-        // Results stored by offset for ordering
-        let mut pending_results: BTreeMap<usize, Vec<serde_json::Value>> = BTreeMap::new();
-        let mut futures: FuturesUnordered<FetchFuture> = FuturesUnordered::new();
-
-        // Buffer for checkpointing - process in order
+        let mut state = PhaseCursors::parse(start_cursor.as_deref());
         let mut buffer: Vec<serde_json::Value> = Vec::new();
-        let mut next_expected_offset = start_offset;
         let mut total_fetched = 0;
 
-        // Start initial batch of concurrent requests
-        for stream_id in 0..CONCURRENCY {
-            let offset = next_offset.fetch_add(max_page_size, Ordering::SeqCst);
-            futures.push(Self::create_fetch_task(
-                client.clone(),
-                self.base_url.clone(),
-                offset,
-                max_page_size,
-                Arc::clone(&semaphore),
-                Arc::clone(&done),
-                stream_id,
-            ));
-        }
+        for &(closed, label) in PHASES {
+            // Skip phases the caller has already drained.
+            let initial_after = match state.cursors.get(label) {
+                Some(None) => continue,
+                Some(Some(c)) => Some(c.clone()),
+                None => None,
+            };
 
-        while let Some(result) = futures.next().await {
-            let (stream_id, offset, markets) = result?;
-            let count = markets.len();
-
-            if count > 0 {
-                pending_results.insert(offset, markets);
-            }
-
-            // Check if this page signals end of data
-            if count < max_page_size {
-                done.store(true, Ordering::SeqCst);
-            }
-
-            // Queue next request if not done (reuse stream_id)
-            if !done.load(Ordering::SeqCst) {
-                let next = next_offset.fetch_add(max_page_size, Ordering::SeqCst);
-                futures.push(Self::create_fetch_task(
-                    client.clone(),
-                    self.base_url.clone(),
-                    next,
+            let mut after = initial_after;
+            let mut iteration = 0;
+            loop {
+                let (mut markets, next) = Self::fetch_phase_page(
+                    &client,
+                    &self.base_url,
+                    closed,
+                    after.as_deref(),
                     max_page_size,
-                    Arc::clone(&semaphore),
-                    Arc::clone(&done),
-                    stream_id,
-                ));
-            }
+                )
+                .await?;
 
-            // Process results in order
-            while let Some(markets) = pending_results.remove(&next_expected_offset) {
-                let page_count = markets.len();
-                total_fetched += page_count;
+                let count = markets.len();
+                total_fetched += count;
+                buffer.append(&mut markets);
+
+                state.cursors.insert(label.to_string(), next.clone());
+                after = next;
 
                 info!(
                     exchange = "polymarket",
-                    offset = next_expected_offset,
-                    page_count,
+                    phase = label,
+                    iteration,
+                    page_count = count,
                     buffer_size = buffer.len(),
                     total = total_fetched,
                     "Fetched page"
                 );
+                iteration += 1;
 
-                buffer.extend(markets);
-                next_expected_offset += max_page_size;
-
-                // Checkpoint if buffer exceeds interval
                 while buffer.len() >= checkpoint_interval {
-                    let checkpoint_data: Vec<_> = buffer.drain(..checkpoint_interval).collect();
-                    let cursor_str = next_expected_offset.to_string();
-                    on_checkpoint(&checkpoint_data, &cursor_str).await?;
-
-                    // Explicitly release memory
+                    let chunk: Vec<_> = buffer.drain(..checkpoint_interval).collect();
+                    let cursor_str = state.serialize();
+                    on_checkpoint(&chunk, &cursor_str).await?;
                     buffer.shrink_to_fit();
+                }
+
+                if after.is_none() {
+                    break;
                 }
             }
         }
 
-        // Get final offset for cursor
-        let final_offset = next_expected_offset;
-
-        // Drop client to close connections
         drop(client);
-
-        // Shrink buffer to release unused memory
         buffer.shrink_to_fit();
 
         Ok(FetchResult {
             markets: buffer,
-            final_cursor: Some(final_offset.to_string()),
+            final_cursor: Some(state.serialize()),
             total_fetched,
         })
     }

--- a/engine/exchanges/polymarket/tests/exchange_tests.rs
+++ b/engine/exchanges/polymarket/tests/exchange_tests.rs
@@ -3,43 +3,81 @@ use px_exchange_polymarket::{Polymarket, PolymarketConfig};
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-fn sample_events_response() -> serde_json::Value {
-    serde_json::json!([
-        {
-            "id": "event-1",
-            "title": "Weather Event",
-            "markets": [
-                {
-                    "id": "123",
-                    "conditionId": "123",
-                    "question": "Will it rain tomorrow?",
-                    "outcomes": "[\"Yes\", \"No\"]",
-                    "outcomePrices": "[\"0.65\", \"0.35\"]",
-                    "volumeNum": 50000.0,
-                    "liquidityNum": 10000.0,
-                    "minimum_tick_size": 0.01,
-                    "description": "Weather prediction market"
-                }
-            ]
-        },
-        {
-            "id": "event-2",
-            "title": "Crypto Event",
-            "markets": [
-                {
-                    "id": "456",
-                    "conditionId": "456",
-                    "question": "Bitcoin > $100k by EOY?",
-                    "outcomes": "[\"Yes\", \"No\"]",
-                    "outcomePrices": "[\"0.42\", \"0.58\"]",
-                    "volumeNum": 1000000.0,
-                    "liquidityNum": 250000.0,
-                    "minimum_tick_size": 0.001,
-                    "description": "Crypto price prediction"
-                }
-            ]
-        }
-    ])
+/// /markets/keyset returns `{markets: [...], next_cursor: ...}` (wrapped),
+/// not bare events. Use this whenever the test exercises the general
+/// `fetch_markets` path.
+fn sample_markets_keyset() -> serde_json::Value {
+    serde_json::json!({
+        "markets": [
+            {
+                "id": "123",
+                "conditionId": "123",
+                "question": "Will it rain tomorrow?",
+                "outcomes": "[\"Yes\", \"No\"]",
+                "outcomePrices": "[\"0.65\", \"0.35\"]",
+                "volumeNum": 50000.0,
+                "liquidityNum": 10000.0,
+                "minimum_tick_size": 0.01,
+                "description": "Weather prediction market"
+            },
+            {
+                "id": "456",
+                "conditionId": "456",
+                "question": "Bitcoin > $100k by EOY?",
+                "outcomes": "[\"Yes\", \"No\"]",
+                "outcomePrices": "[\"0.42\", \"0.58\"]",
+                "volumeNum": 1000000.0,
+                "liquidityNum": 250000.0,
+                "minimum_tick_size": 0.001,
+                "description": "Crypto price prediction"
+            }
+        ],
+        "next_cursor": null
+    })
+}
+
+/// /events/keyset returns `{events: [{id, markets:[...]}, ...], next_cursor}`.
+/// Used for the series_id-filtered path only.
+fn sample_events_keyset() -> serde_json::Value {
+    serde_json::json!({
+        "events": [
+            {
+                "id": "event-1",
+                "title": "Weather Event",
+                "markets": [
+                    {
+                        "id": "123",
+                        "conditionId": "123",
+                        "question": "Will it rain tomorrow?",
+                        "outcomes": "[\"Yes\", \"No\"]",
+                        "outcomePrices": "[\"0.65\", \"0.35\"]",
+                        "volumeNum": 50000.0,
+                        "liquidityNum": 10000.0,
+                        "minimum_tick_size": 0.01,
+                        "description": "Weather prediction market"
+                    }
+                ]
+            },
+            {
+                "id": "event-2",
+                "title": "Crypto Event",
+                "markets": [
+                    {
+                        "id": "456",
+                        "conditionId": "456",
+                        "question": "Bitcoin > $100k by EOY?",
+                        "outcomes": "[\"Yes\", \"No\"]",
+                        "outcomePrices": "[\"0.42\", \"0.58\"]",
+                        "volumeNum": 1000000.0,
+                        "liquidityNum": 250000.0,
+                        "minimum_tick_size": 0.001,
+                        "description": "Crypto price prediction"
+                    }
+                ]
+            }
+        ],
+        "next_cursor": null
+    })
 }
 
 fn sample_single_market_response() -> serde_json::Value {
@@ -61,8 +99,8 @@ async fn test_fetch_markets_parses_response() {
     // given
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/events"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(sample_events_response()))
+        .and(path("/markets/keyset"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_markets_keyset()))
         .mount(&mock_server)
         .await;
 
@@ -150,15 +188,14 @@ async fn test_exchange_id_and_name() {
 
 #[tokio::test]
 async fn test_fetch_markets_with_limit() {
-    // given
+    // given — the limit is sent to the server as a query param. The mock
+    // returns whatever it is configured to return regardless of limit; we
+    // don't truncate client-side. Verifying that the param is passed through
+    // and that all returned markets are emitted.
     let mock_server = MockServer::start().await;
-
-    // Return 3 events, each with 1 market
-    let events = serde_json::json!([
-        {
-            "id": "event-1",
-            "title": "Event 1",
-            "markets": [{
+    let payload = serde_json::json!({
+        "markets": [
+            {
                 "id": "m1",
                 "conditionId": "m1",
                 "question": "Market 1?",
@@ -168,12 +205,8 @@ async fn test_fetch_markets_with_limit() {
                 "liquidityNum": 500.0,
                 "minimum_tick_size": 0.01,
                 "description": "First market"
-            }]
-        },
-        {
-            "id": "event-2",
-            "title": "Event 2",
-            "markets": [{
+            },
+            {
                 "id": "m2",
                 "conditionId": "m2",
                 "question": "Market 2?",
@@ -183,12 +216,8 @@ async fn test_fetch_markets_with_limit() {
                 "liquidityNum": 1000.0,
                 "minimum_tick_size": 0.01,
                 "description": "Second market"
-            }]
-        },
-        {
-            "id": "event-3",
-            "title": "Event 3",
-            "markets": [{
+            },
+            {
                 "id": "m3",
                 "conditionId": "m3",
                 "question": "Market 3?",
@@ -198,13 +227,15 @@ async fn test_fetch_markets_with_limit() {
                 "liquidityNum": 1500.0,
                 "minimum_tick_size": 0.01,
                 "description": "Third market"
-            }]
-        }
-    ]);
+            }
+        ],
+        "next_cursor": null
+    });
 
     Mock::given(method("GET"))
-        .and(path("/events"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(events))
+        .and(path("/markets/keyset"))
+        .and(query_param("limit", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(payload))
         .mount(&mock_server)
         .await;
 
@@ -213,16 +244,15 @@ async fn test_fetch_markets_with_limit() {
         .with_verbose(false);
     let exchange = Polymarket::new(config).unwrap();
 
-    // when — pass limit=2 in params
+    // when
     let params = FetchMarketsParams {
         limit: Some(2),
         ..Default::default()
     };
     let (markets, _cursor) = exchange.fetch_markets(&params).await.unwrap();
 
-    // then — Polymarket fetch_markets does not truncate by limit client-side;
-    // it always fetches a full page of 200 events. The mock returns 3 events
-    // with 1 market each, so all 3 markets are returned.
+    // then — mock matched on limit=2 (proves param was sent), returns 3 markets,
+    // we surface all 3 (no client-side truncation).
     assert_eq!(markets.len(), 3);
     assert_eq!(markets[0].id, "m1");
     assert_eq!(markets[1].id, "m2");
@@ -313,8 +343,11 @@ async fn test_fetch_markets_empty_response() {
     // given
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/events"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .and(path("/markets/keyset"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "markets": [],
+            "next_cursor": null
+        })))
         .mount(&mock_server)
         .await;
 
@@ -338,27 +371,24 @@ async fn test_fetch_markets_empty_response() {
 async fn test_fetch_markets_multiple_outcomes() {
     // given — market with 3 outcomes (categorical)
     let mock_server = MockServer::start().await;
-    let events = serde_json::json!([
-        {
-            "id": "event-multi",
-            "title": "Multi-outcome Event",
-            "markets": [{
-                "id": "multi-1",
-                "conditionId": "multi-1",
-                "question": "Who will win the election?",
-                "outcomes": "[\"Alice\", \"Bob\", \"Charlie\"]",
-                "outcomePrices": "[\"0.45\", \"0.35\", \"0.20\"]",
-                "volumeNum": 200000.0,
-                "liquidityNum": 50000.0,
-                "minimum_tick_size": 0.01,
-                "description": "Election market with 3 candidates"
-            }]
-        }
-    ]);
+    let payload = serde_json::json!({
+        "markets": [{
+            "id": "multi-1",
+            "conditionId": "multi-1",
+            "question": "Who will win the election?",
+            "outcomes": "[\"Alice\", \"Bob\", \"Charlie\"]",
+            "outcomePrices": "[\"0.45\", \"0.35\", \"0.20\"]",
+            "volumeNum": 200000.0,
+            "liquidityNum": 50000.0,
+            "minimum_tick_size": 0.01,
+            "description": "Election market with 3 candidates"
+        }],
+        "next_cursor": null
+    });
 
     Mock::given(method("GET"))
-        .and(path("/events"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(events))
+        .and(path("/markets/keyset"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(payload))
         .mount(&mock_server)
         .await;
 
@@ -388,29 +418,26 @@ async fn test_fetch_markets_multiple_outcomes() {
 async fn test_fetch_markets_with_additional_fields() {
     // given — market with clobTokenIds, conditionId, and slug
     let mock_server = MockServer::start().await;
-    let events = serde_json::json!([
-        {
-            "id": "event-full",
-            "title": "Full Fields Event",
-            "markets": [{
-                "id": "market-1",
-                "conditionId": "cond-123",
-                "question": "Test market with tokens",
-                "outcomes": "[\"Yes\", \"No\"]",
-                "outcomePrices": "[\"0.75\", \"0.25\"]",
-                "volumeNum": 100000.0,
-                "liquidityNum": 25000.0,
-                "minimum_tick_size": 0.01,
-                "description": "Market with full fields",
-                "clobTokenIds": "[\"token1\", \"token2\"]",
-                "slug": "test-market-slug"
-            }]
-        }
-    ]);
+    let payload = serde_json::json!({
+        "markets": [{
+            "id": "market-1",
+            "conditionId": "cond-123",
+            "question": "Test market with tokens",
+            "outcomes": "[\"Yes\", \"No\"]",
+            "outcomePrices": "[\"0.75\", \"0.25\"]",
+            "volumeNum": 100000.0,
+            "liquidityNum": 25000.0,
+            "minimum_tick_size": 0.01,
+            "description": "Market with full fields",
+            "clobTokenIds": "[\"token1\", \"token2\"]",
+            "slug": "test-market-slug"
+        }],
+        "next_cursor": null
+    });
 
     Mock::given(method("GET"))
-        .and(path("/events"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(events))
+        .and(path("/markets/keyset"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(payload))
         .mount(&mock_server)
         .await;
 
@@ -451,27 +478,24 @@ async fn test_fetch_markets_with_additional_fields() {
 async fn test_market_volume_and_liquidity() {
     // given
     let mock_server = MockServer::start().await;
-    let events = serde_json::json!([
-        {
-            "id": "event-vol",
-            "title": "Volume Event",
-            "markets": [{
-                "id": "vol-market",
-                "conditionId": "vol-market",
-                "question": "Volume test market?",
-                "outcomes": "[\"Yes\", \"No\"]",
-                "outcomePrices": "[\"0.55\", \"0.45\"]",
-                "volumeNum": 987654.32,
-                "liquidityNum": 123456.78,
-                "minimum_tick_size": 0.001,
-                "description": "Market for volume/liquidity testing"
-            }]
-        }
-    ]);
+    let payload = serde_json::json!({
+        "markets": [{
+            "id": "vol-market",
+            "conditionId": "vol-market",
+            "question": "Volume test market?",
+            "outcomes": "[\"Yes\", \"No\"]",
+            "outcomePrices": "[\"0.55\", \"0.45\"]",
+            "volumeNum": 987654.32,
+            "liquidityNum": 123456.78,
+            "minimum_tick_size": 0.001,
+            "description": "Market for volume/liquidity testing"
+        }],
+        "next_cursor": null
+    });
 
     Mock::given(method("GET"))
-        .and(path("/events"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(events))
+        .and(path("/markets/keyset"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(payload))
         .mount(&mock_server)
         .await;
 
@@ -542,53 +566,62 @@ async fn test_fetch_market_single_returns_correct_exchange_field() {
 }
 
 // ---------------------------------------------------------------------------
-// fetch_markets: MarketStatusFilter::All returns all statuses
+// fetch_markets: status filter (closed=false / closed=true / two-phase All)
 // ---------------------------------------------------------------------------
 
-fn sample_mixed_status_events() -> serde_json::Value {
-    serde_json::json!([
-        {
-            "id": "event-mixed",
-            "title": "Mixed Status Event",
-            "markets": [
-                {
-                    "id": "pm-active",
-                    "conditionId": "pm-active",
-                    "question": "Active market?",
-                    "outcomes": "[\"Yes\", \"No\"]",
-                    "outcomePrices": "[\"0.60\", \"0.40\"]",
-                    "volumeNum": 1000.0,
-                    "liquidityNum": 500.0,
-                    "minimum_tick_size": 0.01,
-                    "description": "Currently active",
-                    "active": true,
-                    "closed": false
-                },
-                {
-                    "id": "pm-closed",
-                    "conditionId": "pm-closed",
-                    "question": "Closed market?",
-                    "outcomes": "[\"Yes\", \"No\"]",
-                    "outcomePrices": "[\"0.90\", \"0.10\"]",
-                    "volumeNum": 5000.0,
-                    "liquidityNum": 0.0,
-                    "minimum_tick_size": 0.01,
-                    "description": "Already settled",
-                    "active": false,
-                    "closed": true
-                }
-            ]
-        }
-    ])
+fn active_market_payload() -> serde_json::Value {
+    serde_json::json!({
+        "markets": [{
+            "id": "pm-active",
+            "conditionId": "pm-active",
+            "question": "Active market?",
+            "outcomes": "[\"Yes\", \"No\"]",
+            "outcomePrices": "[\"0.60\", \"0.40\"]",
+            "volumeNum": 1000.0,
+            "liquidityNum": 500.0,
+            "minimum_tick_size": 0.01,
+            "description": "Currently active",
+            "active": true,
+            "closed": false
+        }],
+        "next_cursor": null
+    })
+}
+
+fn closed_market_payload() -> serde_json::Value {
+    serde_json::json!({
+        "markets": [{
+            "id": "pm-closed",
+            "conditionId": "pm-closed",
+            "question": "Closed market?",
+            "outcomes": "[\"Yes\", \"No\"]",
+            "outcomePrices": "[\"0.90\", \"0.10\"]",
+            "volumeNum": 5000.0,
+            "liquidityNum": 0.0,
+            "minimum_tick_size": 0.01,
+            "description": "Already settled",
+            "active": false,
+            "closed": true
+        }],
+        "next_cursor": null
+    })
 }
 
 #[tokio::test]
 async fn test_fetch_markets_status_all_returns_all_statuses() {
-    // given
+    // given — All filter is implemented as a sequential two-phase drain:
+    // closed=false page first, then closed=true. Caller paginates twice.
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/events"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(sample_mixed_status_events()))
+        .and(path("/markets/keyset"))
+        .and(query_param("closed", "false"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(active_market_payload()))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/markets/keyset"))
+        .and(query_param("closed", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(closed_market_payload()))
         .mount(&mock_server)
         .await;
 
@@ -597,19 +630,30 @@ async fn test_fetch_markets_status_all_returns_all_statuses() {
         .with_verbose(false);
     let exchange = Polymarket::new(config).unwrap();
 
-    // when
+    // when — first page: drains closed=false, returns transition cursor
     let params = FetchMarketsParams {
         status: Some(MarketStatusFilter::All),
         ..Default::default()
     };
-    let (markets, _) = exchange.fetch_markets(&params).await.unwrap();
+    let (page1, cursor1) = exchange.fetch_markets(&params).await.unwrap();
 
-    // then — both active and closed markets returned
-    assert_eq!(markets.len(), 2);
+    // then — only the active market on page 1, but cursor is set (transition).
+    assert_eq!(page1.len(), 1);
+    assert_eq!(page1[0].id, "pm-active");
+    assert!(cursor1.is_some(), "All filter must emit transition cursor");
 
-    let ids: Vec<&str> = markets.iter().map(|m| m.id.as_str()).collect();
-    assert!(ids.contains(&"pm-active"));
-    assert!(ids.contains(&"pm-closed"));
+    // when — second page: drains closed=true with the transition cursor.
+    let params2 = FetchMarketsParams {
+        status: Some(MarketStatusFilter::All),
+        cursor: cursor1,
+        ..Default::default()
+    };
+    let (page2, cursor2) = exchange.fetch_markets(&params2).await.unwrap();
+
+    // then — only the closed market on page 2; cursor is None (drained).
+    assert_eq!(page2.len(), 1);
+    assert_eq!(page2[0].id, "pm-closed");
+    assert!(cursor2.is_none());
 }
 
 #[tokio::test]
@@ -617,8 +661,9 @@ async fn test_fetch_markets_status_active_filters_correctly() {
     // given
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/events"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(sample_mixed_status_events()))
+        .and(path("/markets/keyset"))
+        .and(query_param("closed", "false"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(active_market_payload()))
         .mount(&mock_server)
         .await;
 
@@ -645,8 +690,9 @@ async fn test_fetch_markets_status_resolved_filters_correctly() {
     // given
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/events"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(sample_mixed_status_events()))
+        .and(path("/markets/keyset"))
+        .and(query_param("closed", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(closed_market_payload()))
         .mount(&mock_server)
         .await;
 
@@ -669,17 +715,18 @@ async fn test_fetch_markets_status_resolved_filters_correctly() {
 }
 
 // ---------------------------------------------------------------------------
-// fetch_markets: series_id filtering
+// fetch_markets: series_id routes through /events/keyset (events-nested)
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn test_fetch_markets_with_series_id() {
-    // given
+    // given — series_id queries route through /events/keyset because
+    // /markets/keyset has no series filter.
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/events"))
+        .and(path("/events/keyset"))
         .and(query_param("series_id", "10345"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(sample_events_response()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_events_keyset()))
         .mount(&mock_server)
         .await;
 
@@ -695,7 +742,7 @@ async fn test_fetch_markets_with_series_id() {
     };
     let (markets, _) = exchange.fetch_markets(&params).await.unwrap();
 
-    // then — mocks only match when series_id=10345 is in the query string
+    // then — mock matched on series_id=10345
     assert_eq!(markets.len(), 2);
 }
 


### PR DESCRIPTION
## Summary

- Migrates Polymarket `fetch_markets` from the offset-based `/events` route to the new cursor-based `/markets/keyset` (added upstream 2026-04-10). Polymarket is steering away from offset pagination, and `/markets/keyset` is the long-term primary surface.
- Routing now: `event_id` → `/events/{id}`; `series_id` → `/events/keyset?series_id=…`; otherwise → `/markets/keyset`. All three are cursor-based.
- `MarketStatusFilter::All` is implemented as a sequential two-phase drain (`closed=false` → `closed=true`) with a compound JSON cursor `{"p","c"}`, since Polymarket has no native "all" mode. Caller paginates twice.
- `params.limit` is now sent to the server (was silently ignored).
- Maps `feeSchedule.rate` (2026-03-31) to `maker_fee_bps`/`taker_fee_bps` as the primary source; legacy `makerBaseFee`/`takerBaseFee` fall back.
- Bulk fetcher (`engine/exchanges/polymarket/src/fetcher.rs`) rewritten as sequential two-phase cursor drain with `PhaseCursors` for resumable checkpoints. The 15-way concurrency from offset paging is gone — keyset cursors are inherently sequential within a stream.

## Stacked on #72

This PR is stacked on `feat/manifest-trim` (#72). The first commit is the manifest trim; this PR's only commit is the keyset migration. After #72 merges, this PR's base will retarget cleanly to `main`.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p px-exchange-polymarket` — 74/74 passing (54 unit + 20 integration). Includes:
  - `test_fetch_markets_parses_response` — basic /markets/keyset round-trip
  - `test_fetch_markets_with_limit` — limit param is sent to server
  - `test_fetch_markets_status_active_filters_correctly` — `closed=false` mock
  - `test_fetch_markets_status_resolved_filters_correctly` — `closed=true` mock
  - `test_fetch_markets_status_all_returns_all_statuses` — two-phase drain across two paginated calls
  - `test_fetch_markets_with_series_id` — `/events/keyset?series_id=…` mock
  - `test_fetch_markets_with_event_id` / `_with_event_slug` — single-event short-circuit unchanged
- [ ] Manual smoke against live Polymarket Gamma (recommended before merge)

## Out of scope

- No changes to Kalshi (already on cursor-paginated `/markets`).
- No new fields on `Market` or `FetchMarketsParams`. Existing fields only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)