### PR TITLE
chore: rename repository URLs to openpx-trade org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for your interest in contributing to OpenPX. This guide will help you 
 ### Getting Started
 
 ```bash
-git clone https://github.com/openpx/openpx.git
+git clone https://github.com/openpx-trade/openpx.git
 cd openpx
 cargo check --workspace
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ version = "0.2.6"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT"
-repository = "https://github.com/openpx/openpx"
+repository = "https://github.com/openpx-trade/openpx"
 authors = ["Milind Pathiyal"]
 
 [workspace.dependencies]

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 dependencies = ["pydantic>=2.0"]
 
 [project.urls]
-Homepage = "https://github.com/openpx/openpx"
-Repository = "https://github.com/openpx/openpx"
+Homepage = "https://github.com/openpx-trade/openpx"
+Repository = "https://github.com/openpx-trade/openpx"
 
 [project.optional-dependencies]
 dev = ["datamodel-code-generator>=0.25", "maturin>=1.5,<2.0"]

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -8,9 +8,9 @@
   "author": "Milind Pathiyal",
   "repository": {
     "type": "git",
-    "url": "https://github.com/openpx/openpx"
+    "url": "https://github.com/openpx-trade/openpx"
   },
-  "homepage": "https://github.com/openpx/openpx",
+  "homepage": "https://github.com/openpx-trade/openpx",
   "keywords": [
     "prediction-market",
     "trading",


### PR DESCRIPTION
## Summary

Mechanical rename of the GitHub URL from `openpx/openpx` → `openpx-trade/openpx` in the four files that pin it:

- `Cargo.toml` — workspace `repository = …` (crates.io metadata)
- `CONTRIBUTING.md` — clone instructions
- `sdks/python/pyproject.toml` — PyPI `Homepage` + `Repository` URLs
- `sdks/typescript/package.json` — npm `repository.url` + `homepage`

Catches a stale URL in the TS package.json that was missed by the original local edit.

## Test plan

- [x] `cargo check --workspace`
- [ ] No CI changes needed (URLs are metadata-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)