### PR TITLE
chore(claude): refresh project profile and add references doc

### DIFF
--- a/.claude/Claude.md
+++ b/.claude/Claude.md
@@ -1,32 +1,61 @@
 # Claude Project Profile: OpenPX
 
-## Overview
+## What OpenPX Is
 
-OpenPX is an open-source, CCXT-style unified SDK for prediction markets in Rust. Users bring their own exchange credentials and trade directly through the unified `Exchange` trait.
+OpenPX is a **unified API for prediction markets** — one `Exchange` trait, one set of models, one shape that hides Kalshi's and Polymarket's per-exchange quirks behind a single interface. Users bring their own credentials and trade through the unified surface. CCXT, but for prediction markets, in Rust.
 
-## Engineering Principles
+The codebase is **lean, stable, HFT-oriented, and elegantly designed**. Every change is judged against those four properties.
 
-**SPEED IS EVERYTHING.** Every nanosecond counts — in network I/O, internal calculations,
-serialization, deserialization, matching, routing, everything. This is an HFT-oriented
-library where latency is the difference between profit and loss for users. Never introduce
-unnecessary overhead. Always ask: "is there a faster way to do this?"
+- **Lean** — no file, dependency, or abstraction lands unless it pulls its weight. Three similar lines beat a premature abstraction.
+- **Stable** — the unified surface is a contract. Breaking it without a migration plan is not acceptable.
+- **HFT-oriented** — every nanosecond counts. Zero-alloc hot paths, lock-free where possible, mechanical sympathy over OOP layering.
+- **Elegantly designed** — naming reads like prose; shapes are obvious; one concept lives in one place.
 
-- **Performance is Non-Negotiable:** Prioritize lowest possible latency and minimal memory footprint in every code path.
-- **Mechanical Sympathy:** Favor data-oriented design over deep OOP abstractions.
-- **Zero-Alloc Hot Paths:** Minimize or eliminate memory allocations in hot loops.
-- **Modular Simplicity:** Keep the codebase lean and organized. Do not add dependencies or files unless absolutely necessary.
+## The Unification Mandate
 
-## Technical Standards
-- **Concurrency:** Use lock-free structures where possible; avoid global locks that cause contention.
-- **Memory:** Prefer stack allocation and object pooling over frequent heap allocations.
-- **Validation:** Strict type safety and boundary checking are non-negotiable.
+The single most important property of this codebase is that **the same operation looks identical across every exchange**. If a user fetches markets, places an order, or subscribes to a stream, they should not be able to tell which exchange they're talking to from the call site alone — only from the data flowing back.
+
+Before writing or accepting any code, ask:
+
+1. **Is this shape already in the unified API?** If yes, conform to it. If no, design the shape first, then implement both exchanges against it.
+2. **Does both Kalshi *and* Polymarket need this surface?** If only one does, it does not belong on the unified trait — push it to an exchange-specific extension or rethink whether the user actually needs it.
+3. **Does the field naming reflect the unified vocabulary, not the exchange's vocabulary?** Kalshi calls something `ticker`, Polymarket calls it `condition_id` — the unified model picks one name (or a more general one) and both implementations map into it. Never leak per-exchange terminology.
+4. **Does the error map cleanly into `ExchangeError`?** Per-exchange error variants stay private; only the unified hierarchy crosses the boundary.
+
+When you encounter divergence on `main`, treat it as a bug, not a feature. Reconcile.
+
+## Reference Discipline (HARD RULE)
+
+**Any time you are asked to add, change, or unify an endpoint, model, error, field, or stream — you must first look it up in the upstream reference docs for both exchanges.** No exceptions, no "I remember how it works."
+
+Examples of requests that trigger doc lookup:
+- "ensure the markets endpoints are unified correctly" → fetch markets endpoints from both exchanges' OpenAPI specs, compare fields, design the unified shape, then implement.
+- "add a fetch_volume endpoint" → search both exchanges' docs for `volume`, find every endpoint/field that exposes it, then design the unified call.
+- "fix order cancellation on Polymarket" → fetch the Polymarket CLOB cancel spec, fetch Kalshi's cancel spec to confirm the unified contract still holds, then change code.
+- "add a new field to the orderbook" → fetch both exchanges' orderbook channel specs, see what they actually publish, then update the model.
+
+The lookup workflow:
+
+1. **Search the keyword against the reference URLs below** using `WebFetch` (Tier 1 specs first, then prose pages).
+2. **Diff the two exchanges' shapes** — what does each call it, what fields exist, what's optional, what's typed how.
+3. **Check the changelogs** for any recent breaking changes that touch the keyword.
+4. **Then design the unified shape** that maps both into one model.
+5. **Then write code.**
+
+If you skip step 1, you will produce drift. Drift is the one thing this codebase cannot tolerate.
+
+## Reference URLs
+
+All upstream doc URLs (Kalshi + Polymarket, Tier 1 specs/changelogs/discovery + Tier 2 prose) live in a single source of truth: **`.claude/references.md`**. Read that file before any unification work — do not hardcode URLs from memory.
+
+The `/unify` skill (`.claude/commands/unify.md`) reads from the same file.
 
 ## Workspace Structure
 
 ```
 openpx/
 ├── engine/                   # Rust core — powers everything
-│   ├── core/                 # Core types, traits, timing, error handling
+│   ├── core/                 # Unified types, traits, timing, errors
 │   │   ├── src/exchange/     # Exchange trait, manifests, normalizers, rate limiting
 │   │   ├── src/models/       # Market, Order, Position, Orderbook, Trade
 │   │   ├── src/events.rs     # Canonical event ID handling
@@ -34,13 +63,13 @@ openpx/
 │   │   ├── src/error.rs      # OpenPxError hierarchy + define_exchange_error! macro
 │   │   ├── src/utils/        # Utility helpers (price conversion)
 │   │   └── src/websocket/    # WebSocket traits
-│   ├── exchanges/            # Exchange implementations
+│   ├── exchanges/
 │   │   ├── kalshi/           # auth, config, error, exchange, fetcher, normalize, websocket
 │   │   └── polymarket/       # auth, config, error, exchange, fetcher, websocket, approvals, clob, ctf, signer, relayer, swap, client, diagnostics
 │   ├── sdk/                  # Unified facade (enum dispatch)
-│   ├── cli/                  # CLI tool for testing APIs & WebSocket streams
+│   ├── cli/                  # CLI for testing APIs & WebSocket streams
 │   └── schema/               # JSON Schema export binary
-├── sdks/                     # Language SDKs
+├── sdks/
 │   ├── python/               # PyO3 + auto-generated Pydantic models
 │   └── typescript/           # NAPI-RS + auto-generated TS types
 ├── docs/                     # Mintlify documentation site (docs.json + MDX)
@@ -48,19 +77,19 @@ openpx/
 └── justfile                  # Single-command SDK sync
 ```
 
-## Key Files Reference
+## Key Files
 
-| Purpose | File | Notes |
-|---------|------|-------|
-| Exchange trait | `engine/core/src/exchange/traits.rs` | All exchanges implement this |
-| Exchange manifest base | `engine/core/src/exchange/manifest.rs` | ExchangeManifest struct, PaginationConfig, FieldMapping, Transform |
-| Exchange manifests | `engine/core/src/exchange/manifests/` | Per-exchange configs (kalshi.rs, polymarket.rs) |
-| Timing macros | `engine/core/src/timing.rs` | `timed!` macro + metric name constants |
-| Error types | `engine/core/src/error.rs` | `OpenPxError` hierarchy + `define_exchange_error!` macro |
-| Event IDs | `engine/core/src/events.rs` | Canonical cross-exchange event grouping |
-| WebSocket traits | `engine/core/src/websocket/traits.rs` | WebSocket connection interface |
-| Kalshi exchange | `engine/exchanges/kalshi/src/exchange.rs` | Reference implementation |
-| Market model | `engine/core/src/models/market.rs` | Unified Market type (single struct for all exchanges) |
+| Purpose | File |
+|---------|------|
+| Exchange trait (the unified contract) | `engine/core/src/exchange/traits.rs` |
+| Exchange manifest base | `engine/core/src/exchange/manifest.rs` |
+| Per-exchange manifests | `engine/core/src/exchange/manifests/{kalshi,polymarket}.rs` |
+| Timing macros | `engine/core/src/timing.rs` |
+| Error types | `engine/core/src/error.rs` |
+| Event IDs | `engine/core/src/events.rs` |
+| WebSocket traits | `engine/core/src/websocket/traits.rs` |
+| Reference exchange impl | `engine/exchanges/kalshi/src/exchange.rs` |
+| Unified Market model | `engine/core/src/models/market.rs` |
 
 ## Common Patterns
 
@@ -79,12 +108,11 @@ let result = timed!(
 
 ### Error Handling
 
-Each exchange defines its error type using the `define_exchange_error!` macro, then maps to `ExchangeError`:
+Each exchange defines its error type using `define_exchange_error!`, then maps to the unified `ExchangeError`. Per-exchange variants stay private; only the unified hierarchy crosses the trait boundary.
 
 ```rust
 use px_core::define_exchange_error;
 
-// Define exchange-specific error (auto-includes Http, Api, RateLimited, AuthRequired, MarketNotFound)
 define_exchange_error!(KalshiError {
     #[error("authentication failed: {0}")]
     AuthFailed(String),
@@ -92,7 +120,6 @@ define_exchange_error!(KalshiError {
     InsufficientBalance(String),
 });
 
-// Map exchange-specific errors to unified ExchangeError
 impl From<KalshiError> for px_core::ExchangeError {
     fn from(err: KalshiError) -> Self {
         match err {
@@ -108,28 +135,18 @@ impl From<KalshiError> for px_core::ExchangeError {
 ## Common Commands
 
 ```bash
-# Check workspace
 cargo check --workspace
-
-# Run clippy with warnings as errors
 cargo clippy --workspace -- -D warnings
-
-# Run tests
 cargo test --workspace
-
-# Format code
 cargo fmt --all
-
-# Build release
 cargo build --release --workspace
 ```
 
 ## Best Practices
-- **Code Style:** All code must be lean, minimal, and organized, so it's easy to read.
-- **Testing:** All exchange implementations should have tests.
 
-## API Reference
-
-Always refer to the official documentation for each prediction market when implementing solutions:
-- Polymarket: https://docs.polymarket.com/developers/
-- Kalshi: https://docs.kalshi.com/
+- **Code style:** lean, minimal, organized. Easy to read at a glance.
+- **Comments:** default to none. Only write one when the *why* is non-obvious.
+- **Testing:** every exchange implementation has tests; every unified-trait method has a contract test that runs against both exchanges.
+- **Allocations:** avoid in hot paths. Reuse buffers, prefer stack, pool when needed.
+- **Concurrency:** lock-free where possible; never a global lock on a hot path.
+- **Validation:** strict types, boundary checks at the edge — internal code trusts internal code.

--- a/.claude/references.md
+++ b/.claude/references.md
@@ -1,0 +1,88 @@
+# OpenPX Upstream References
+
+Single source of truth for every upstream doc URL the OpenPX codebase tracks.
+`CLAUDE.md` and `.claude/commands/unify.md` both read from this file — update here, not in either of those.
+
+Tier conventions:
+- **Tier 1** — machine-readable specs, changelog, discovery index. Always fetch first when a keyword could touch them.
+- **Tier 2** — operational prose pages. Fetch when the keyword maps to that area.
+
+---
+
+## Kalshi
+
+Single base: `https://docs.kalshi.com`. One REST surface, one WS surface.
+
+### Tier 1 — machine-readable specs
+- REST: https://docs.kalshi.com/openapi.yaml
+- WebSocket: https://docs.kalshi.com/asyncapi.yaml
+
+### Tier 1 — changelog and discovery
+- Changelog: https://docs.kalshi.com/changelog
+- Discovery index: https://docs.kalshi.com/llms.txt
+- Full discovery: https://docs.kalshi.com/llms-full.txt
+
+### Tier 2 — operational pages
+- https://docs.kalshi.com/getting_started/rate_limits.md
+- https://docs.kalshi.com/getting_started/market_lifecycle.md
+- https://docs.kalshi.com/getting_started/orderbook_responses.md
+- https://docs.kalshi.com/getting_started/fee_rounding.md
+- https://docs.kalshi.com/getting_started/pagination.md
+- https://docs.kalshi.com/getting_started/fixed_point_migration.md
+- https://docs.kalshi.com/getting_started/historical_data.md
+- https://docs.kalshi.com/getting_started/targets_and_milestones.md
+- https://docs.kalshi.com/getting_started/rfqs.md
+- https://docs.kalshi.com/getting_started/terms.md
+
+---
+
+## Polymarket
+
+The API is split across 4 services with separate base URLs. Specs are NOT at the conventional `/openapi.yaml` root — they live under `/api-spec/`.
+
+### Service map
+- **Gamma API** (`https://gamma-api.polymarket.com`) — markets/events/tags, no auth
+- **Data API** (`https://data-api.polymarket.com`) — positions/trades/leaderboards, no auth
+- **CLOB API** (`https://clob.polymarket.com`) — orderbook + trading, L1/L2 auth
+- **Bridge API** (`https://bridge.polymarket.com`) — deposits/withdrawals
+
+### Tier 1 — machine-readable specs
+- CLOB: https://docs.polymarket.com/api-spec/clob-openapi.yaml
+- Data: https://docs.polymarket.com/api-spec/data-openapi.yaml
+- Gamma: https://docs.polymarket.com/api-spec/gamma-openapi.yaml
+- Bridge: https://docs.polymarket.com/api-spec/bridge-openapi.yaml
+- Relayer: https://docs.polymarket.com/api-spec/relayer-openapi.yaml
+- Market WS: https://docs.polymarket.com/asyncapi.json
+- User WS: https://docs.polymarket.com/asyncapi-user.json
+- Sports WS (only if scope expands): https://docs.polymarket.com/asyncapi-sports.json
+
+### Tier 1 — changelog, discovery, on-chain
+- Changelog: https://docs.polymarket.com/changelog.md
+- Discovery index: https://docs.polymarket.com/llms.txt
+- Full discovery: https://docs.polymarket.com/llms-full.txt
+- On-chain contracts (silent breakage if redeployed): https://docs.polymarket.com/resources/contracts.md
+
+### Tier 2 — operational pages
+- https://docs.polymarket.com/api-reference/rate-limits.md
+- https://docs.polymarket.com/api-reference/authentication.md
+- https://docs.polymarket.com/concepts/markets-events.md
+- https://docs.polymarket.com/concepts/order-lifecycle.md
+- https://docs.polymarket.com/concepts/prices-orderbook.md
+- https://docs.polymarket.com/concepts/positions-tokens.md
+- https://docs.polymarket.com/concepts/resolution.md
+- https://docs.polymarket.com/concepts/pusd.md
+- https://docs.polymarket.com/trading/fees.md
+- https://docs.polymarket.com/trading/matching-engine.md
+- https://docs.polymarket.com/trading/gasless.md
+- https://docs.polymarket.com/trading/orderbook.md
+- https://docs.polymarket.com/trading/orders/create.md
+- https://docs.polymarket.com/trading/orders/cancel.md
+- https://docs.polymarket.com/trading/clients/l1.md
+- https://docs.polymarket.com/trading/clients/l2.md
+- https://docs.polymarket.com/resources/error-codes.md
+- https://docs.polymarket.com/resources/blockchain-data.md
+- https://docs.polymarket.com/market-data/websocket/overview.md
+- https://docs.polymarket.com/market-data/websocket/market-channel.md
+- https://docs.polymarket.com/market-data/websocket/user-channel.md
+- https://docs.polymarket.com/market-data/websocket/rtds.md
+- https://docs.polymarket.com/advanced/neg-risk.md


### PR DESCRIPTION
## Summary

- `.claude/Claude.md` (modified): tightens the unification mandate, adds the reference-discipline rule (look up upstream specs before changing any unified endpoint/model/error/field/stream), points the workflow at the new `.claude/references.md` source of truth, and updates the workspace layout description.
- `.claude/references.md` (new, 88 lines): single source of truth for every upstream doc URL the codebase tracks — Kalshi + Polymarket Tier 1 specs/changelogs/discovery indexes + Tier 2 operational prose. `CLAUDE.md` and the `/unify` slash command read from here instead of hardcoding URLs from memory.

## Why

The reference-discipline rule was already implicit; this makes it explicit and gives it one canonical home so updates land in one file instead of being duplicated between `CLAUDE.md` and the `/unify` command's prompt.

## Test plan

- No code changes. These are Claude Code project-config files and have no runtime effect.
- [ ] Reviewer sanity check that the URL list in `references.md` matches what the team actually uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)