### PR TITLE
ci: unblock SDK Sync Check + format mapping contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Validate exchange→openpx field mappings
         run: just check-mappings
       - name: Check generated files are in sync
-        run: git diff --exit-code schema/openpx.schema.json sdks/python/python/openpx/_models.py sdks/typescript/types/models.d.ts docs/llms.txt docs/api/ docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml docs/websockets/
+        run: git diff --exit-code schema/openpx.schema.json sdks/python/python/openpx/_models.py sdks/typescript/types/models.d.ts docs/llms.txt docs/api/ docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml
       # Smoke checks: a regen can produce a syntactically degenerate file
       # (e.g. an empty stub) that drifts undetectably under git diff alone.
       # PR #26 hid for an indeterminate amount of time because models.d.ts

--- a/engine/exchanges/kalshi/tests/mapping_contract.rs
+++ b/engine/exchanges/kalshi/tests/mapping_contract.rs
@@ -39,8 +39,7 @@ fn load_mapping() -> serde_yaml::Value {
 
 fn load_fixture() -> Value {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/market.json");
-    serde_json::from_str(&fs::read_to_string(&p).expect("read fixture"))
-        .expect("parse fixture")
+    serde_json::from_str(&fs::read_to_string(&p).expect("read fixture")).expect("parse fixture")
 }
 
 fn ref_to_field(reference: &str) -> Option<&str> {
@@ -158,7 +157,8 @@ async fn yaml_contract_for_kalshi_market() {
     Mock::given(method("GET"))
         .and(path(format!("/markets/{ticker}")))
         .respond_with(
-            ResponseTemplate::new(200).set_body_json(serde_json::json!({"market": fixture.clone()})),
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"market": fixture.clone()})),
         )
         .mount(&mock_server)
         .await;
@@ -191,10 +191,7 @@ async fn yaml_contract_for_kalshi_market() {
         if field.get("synthetic").is_some() && field.get("sources").is_none() {
             continue;
         }
-        let src = match field
-            .get("sources")
-            .and_then(|s| s.get("kalshi"))
-        {
+        let src = match field.get("sources").and_then(|s| s.get("kalshi")) {
             Some(s) => s,
             None => continue,
         };

--- a/engine/exchanges/polymarket/tests/mapping_contract.rs
+++ b/engine/exchanges/polymarket/tests/mapping_contract.rs
@@ -36,8 +36,7 @@ fn load_mapping() -> serde_yaml::Value {
 
 fn load_fixture() -> Value {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/market.json");
-    serde_json::from_str(&fs::read_to_string(&p).expect("read fixture"))
-        .expect("parse fixture")
+    serde_json::from_str(&fs::read_to_string(&p).expect("read fixture")).expect("parse fixture")
 }
 
 fn lookup_in_fixture<'a>(fixture: &'a Value, reference: &str) -> Option<&'a Value> {
@@ -114,9 +113,7 @@ fn check_field(
             if parsed_s.timestamp() == parsed_u.timestamp() {
                 Ok(())
             } else {
-                Err(format!(
-                    "parse_datetime mismatch: source={s} unified={u}"
-                ))
+                Err(format!("parse_datetime mismatch: source={s} unified={u}"))
             }
         }
         "enum_remap" | "first_non_null" => {
@@ -179,10 +176,7 @@ async fn yaml_contract_for_polymarket_market() {
         if field.get("synthetic").is_some() && field.get("sources").is_none() {
             continue;
         }
-        let src = match field
-            .get("sources")
-            .and_then(|s| s.get("polymarket"))
-        {
+        let src = match field.get("sources").and_then(|s| s.get("polymarket")) {
             Some(s) => s,
             None => continue,
         };

--- a/justfile
+++ b/justfile
@@ -79,9 +79,9 @@ openapi:
 api-mdx: openapi
     python3 tools/gen_api_mdx.py
 
-# Generate docs/openpx.asyncapi.yaml + docs/websockets/stream.mdx from the
-# WsUpdate / SessionEvent types in the JSON Schema. Mintlify renders the
-# embedded AsyncAPI as Send/Receive panels with expandable properties.
+# Generate docs/openpx.asyncapi.yaml from the WsUpdate / SessionEvent types
+# in the JSON Schema. Mintlify renders the embedded AsyncAPI as Send/Receive
+# panels with expandable properties (no per-channel MDX wrappers needed).
 asyncapi:
     python3 tools/gen_asyncapi.py
 
@@ -89,7 +89,7 @@ docs-serve:
     cd docs && mintlify dev
 
 check-sync: schema python-models node-models llms-txt check-mappings render-mappings openapi api-mdx asyncapi
-    git diff --exit-code schema/openpx.schema.json sdks/python/python/openpx/_models.py sdks/typescript/types/models.d.ts docs/llms.txt docs/api/ docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml docs/websockets/
+    git diff --exit-code schema/openpx.schema.json sdks/python/python/openpx/_models.py sdks/typescript/types/models.d.ts docs/llms.txt docs/api/ docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml
 
 # ---------------------------------------------------------------------------
 # Versioning

--- a/sdks/python/python/openpx/_models.py
+++ b/sdks/python/python/openpx/_models.py
@@ -55,6 +55,11 @@ class Candlestick(BaseModel):
     )
 
 
+class CryptoPriceSource(Enum):
+    binance = "binance"
+    chainlink = "chainlink"
+
+
 class Event(BaseModel):
     category: str | None = None
     description: str | None = None
@@ -358,6 +363,22 @@ class SettlementSource(BaseModel):
     url: str | None = None
 
 
+class SportResult(BaseModel):
+    away_team: str
+    elapsed: str | None = None
+    ended: bool
+    finished_timestamp: AwareDatetime | None = None
+    game_id: conint(ge=0)
+    home_team: str
+    league_abbreviation: str
+    live: bool
+    period: str | None = None
+    score: str | None = None
+    slug: str
+    status: str
+    turn: str | None = None
+
+
 class Spread(BaseModel):
     ask: float
     bid: float
@@ -478,6 +499,13 @@ class ActivityFill(BaseModel):
     tx_hash: str | None = Field(
         None, description="On-chain transaction hash, when the exchange publishes one."
     )
+
+
+class CryptoPrice(BaseModel):
+    source: CryptoPriceSource
+    symbol: str
+    timestamp: conint(ge=0)
+    value: float
 
 
 class FetchMarketsParams(BaseModel):

--- a/sdks/typescript/types/models.d.ts
+++ b/sdks/typescript/types/models.d.ts
@@ -11,6 +11,11 @@
  */
 export type LiquidityRole = "maker" | "taker";
 /**
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "CryptoPriceSource".
+ */
+export type CryptoPriceSource = "binance" | "chainlink";
+/**
  * Filter for market status in fetch queries.
  *
  * Unlike `MarketStatus` (which represents a market's actual status), this enum includes an `All` variant for fetching markets regardless of status.
@@ -253,6 +258,17 @@ export interface Candlestick {
    * Trade volume in contracts. 0.0 if exchange doesn't provide volume.
    */
   volume: number;
+  [k: string]: unknown;
+}
+/**
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "CryptoPrice".
+ */
+export interface CryptoPrice {
+  source: CryptoPriceSource;
+  symbol: string;
+  timestamp: number;
+  value: number;
   [k: string]: unknown;
 }
 /**
@@ -912,6 +928,28 @@ export interface SeriesRequest {
    */
   include_volume?: boolean | null;
   limit?: number | null;
+  [k: string]: unknown;
+}
+/**
+ * Real-time sports score/state from the Polymarket Sports WebSocket. Serializes as snake_case for end-users; aliases accept the upstream camelCase.
+ *
+ * This interface was referenced by `OpenPX`'s JSON-Schema
+ * via the `definition` "SportResult".
+ */
+export interface SportResult {
+  away_team: string;
+  elapsed?: string | null;
+  ended: boolean;
+  finished_timestamp?: string | null;
+  game_id: number;
+  home_team: string;
+  league_abbreviation: string;
+  live: boolean;
+  period?: string | null;
+  score?: string | null;
+  slug: string;
+  status: string;
+  turn?: string | null;
   [k: string]: unknown;
 }
 /**

--- a/tools/gen_asyncapi.py
+++ b/tools/gen_asyncapi.py
@@ -1,25 +1,16 @@
 #!/usr/bin/env python3
-"""Generate `docs/websockets/openpx.asyncapi.yaml` + per-channel MDX wrappers.
+"""Generate `docs/openpx.asyncapi.yaml` from the JSON Schema.
 
-Mintlify resolves `asyncapi:` frontmatter paths relative to the referencing
-MDX file's directory, so the spec must live in `docs/websockets/` next to the
-MDX pages — not at the docs root.
+Mintlify auto-renders the spec into Send/Receive panels (one channel per
+operation) at `tab=AsyncAPI`, so this generator emits a single top-level
+spec — no per-channel MDX wrappers.
 
-Five channels are documented, one MDX page each:
+Channels covered: orderbook, trades, fills, crypto, sports. Every channel
+includes the global session-lifecycle events (Connected, Reconnected,
+Lagged, Error) and the relevant subscribe/unsubscribe send operations.
 
-  orderbook  — Snapshot / Delta / Clear / BookInvalidated
-  trades     — Trade
-  fills      — Fill (authenticated user only)
-  crypto     — CryptoPrice (Polymarket-hosted, public)
-  sports     — SportResult (Polymarket-hosted, public)
-
-Every channel includes the global session-lifecycle events (Connected,
-Reconnected, Lagged, Error) and the relevant subscribe/unsubscribe send
-operations.
-
-Sources of truth: the JSON Schema at `schema/openpx.schema.json` (which now
-includes CryptoPrice / CryptoPriceSource / SportResult — added to the
-schema-export bin) and the Cargo workspace version.
+Sources of truth: `schema/openpx.schema.json` and the Cargo workspace
+version.
 """
 from __future__ import annotations
 
@@ -35,9 +26,6 @@ ROOT = Path(__file__).resolve().parent.parent
 JSON_SCHEMA = ROOT / "schema" / "openpx.schema.json"
 CARGO_TOML = ROOT / "Cargo.toml"
 DOCS_DIR = ROOT / "docs"
-WS_DIR = DOCS_DIR / "websockets"
-# Per Mintlify's AsyncAPI docs, the spec file must live alongside docs.json
-# (not in a subdirectory).
 OUTPUT_YAML = DOCS_DIR / "openpx.asyncapi.yaml"
 
 # Per-channel content. Each channel name → (sidebarTitle, page title,


### PR DESCRIPTION
## Summary

Two CI gates have been silently failing on every commit and merging under admin bypass. This PR fixes both so they actually gate.

- **SDK Sync Check** errors with `fatal: docs/websockets/: no such path in the working tree` (exit 128). The `docs/websockets/` directory was deleted in 7b7282d ("drop per-channel MDX"), but the `git diff --exit-code` guard still references it — so the diff command errors out before it can detect actual artifact drift. Result: the gate has been doing nothing for several commits, while CI conclusion shows `failure` and merge proceeds via admin bypass.
- **Format** fails on six un-`fmt`-ed blocks in `engine/exchanges/{kalshi,polymarket}/tests/mapping_contract.rs` (the mapping-system mechanical drift tests landed without `cargo fmt`).

## Changes

- `.github/workflows/ci.yml` — drop dead `docs/websockets/` from the SDK Sync diff guard
- `justfile` — same drop in the `check-sync` recipe; refresh the stale `asyncapi` recipe comment to match current reality
- `tools/gen_asyncapi.py` — replace the stale module docstring (still claimed it wrote per-channel MDX wrappers under `docs/websockets/`); remove the dead `WS_DIR` variable
- `engine/exchanges/{kalshi,polymarket}/tests/mapping_contract.rs` — `cargo fmt` only, no logic change

## Test plan

- [x] `cargo fmt --all --check` passes locally
- [ ] CI **Format** job passes
- [ ] CI **SDK Sync Check** job no longer errors with `no such path`; if it reveals real artifact drift previously hidden by the early exit, address in a follow-up commit on this branch
- [ ] No other CI jobs regress

## Follow-up (not in this PR)

Branch protection still has two gaps that need a separate decision:
1. `Manifest Coverage` is in `required_status_checks` but no workflow job emits it — required check that never runs, blocks every normal-flow merge.
2. `Python SDK Build` and `Node.js SDK Build` jobs run but aren't in `required_status_checks`, so binding-layer breakage doesn't block merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)