### PR TITLE
refactor(mapping): dedupe mapping-system harnesses (Rust + Python)

### DIFF
--- a/engine/core/Cargo.toml
+++ b/engine/core/Cargo.toml
@@ -17,6 +17,9 @@ simd-json = ["dep:simd-json"]
 # Exchanges enable this feature; px-schema and other non-HTTP consumers
 # stay lightweight.
 http = ["dep:reqwest"]
+# Shared mapping-contract test harness used by every exchange's
+# `tests/mapping_contract.rs`. Enabled via dev-dependencies only.
+test-support = ["dep:serde_yaml"]
 
 [dependencies]
 tokio = { workspace = true }
@@ -34,6 +37,7 @@ metrics = { workspace = true }
 smallvec = { workspace = true }
 ahash = { workspace = true }
 schemars = { version = "0.8", features = ["chrono", "smallvec"], optional = true }
+serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/engine/core/src/lib.rs
+++ b/engine/core/src/lib.rs
@@ -11,6 +11,9 @@ pub mod utils;
 pub mod websocket;
 pub mod ws_decoder;
 
+#[cfg(feature = "test-support")]
+pub mod test_support;
+
 pub use buffer_pool::BufferPool;
 pub use error::*;
 pub use events::*;

--- a/engine/core/src/test_support.rs
+++ b/engine/core/src/test_support.rs
@@ -1,0 +1,222 @@
+//! Shared test harness for the YAML mapping contract.
+//!
+//! Each exchange has a `tests/mapping_contract.rs` that loads the committed
+//! mapping YAML, fetches a market against a mocked upstream, and asserts that
+//! the parsed unified `Market` matches what the YAML's `<exchange>:` sources
+//! claim. The walk + transform vocabulary is identical across exchanges; this
+//! module is the single source of truth for both, so kalshi and polymarket
+//! cannot drift on what `parse_datetime` (or any other transform) means.
+//!
+//! Enabled via the `test-support` feature, which exchanges turn on as a
+//! dev-dependency only. Not compiled into release builds.
+//!
+//! Caveat — same as the per-exchange tests: this verifies *behavioral
+//! equivalence* against a real fixture (the unified value at field `name`
+//! equals the fixture value at the declared `$ref` after the declared
+//! transform). It does not statically prove the code reads exactly that
+//! `$ref` at runtime; sentinel values in the fixture make any source-path
+//! swap detectable in practice.
+
+use std::fs;
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+const REF_PREFIX: &str = "#/components/schemas/Market/properties/";
+
+/// Walk up from `test_manifest_dir` until a `schema/mappings/<name>.yaml` is
+/// found, then load and parse it. The argument is typically
+/// `env!("CARGO_MANIFEST_DIR")` from the calling test crate.
+pub fn load_mapping(test_manifest_dir: &str, mapping_name: &str) -> serde_yaml::Value {
+    let start = PathBuf::from(test_manifest_dir);
+    let mut cur = start.clone();
+    loop {
+        let candidate = cur.join(format!("schema/mappings/{mapping_name}.yaml"));
+        if candidate.is_file() {
+            let body = fs::read_to_string(&candidate).expect("read mapping yaml");
+            return serde_yaml::from_str(&body).expect("parse mapping yaml");
+        }
+        if !cur.pop() {
+            panic!("no schema/mappings/{mapping_name}.yaml found above {start:?}");
+        }
+    }
+}
+
+fn lookup_in_fixture<'a>(fixture: &'a Value, reference: &str) -> Option<&'a Value> {
+    fixture.get(reference.strip_prefix(REF_PREFIX)?)
+}
+
+fn check_field(
+    transform: &str,
+    source: Option<&Value>,
+    unified: Option<&Value>,
+) -> Result<(), String> {
+    let source_present = source.is_some_and(|v| !v.is_null());
+    let unified_present = unified.is_some_and(|v| !v.is_null());
+
+    match transform {
+        "direct" => match (source, unified) {
+            (Some(s), Some(u)) if s == u => Ok(()),
+            (Some(s), Some(u)) => match (s.as_f64(), u.as_f64()) {
+                (Some(a), Some(b)) if (a - b).abs() < 1e-9 => Ok(()),
+                _ => Err(format!("direct mismatch: source={s:?} unified={u:?}")),
+            },
+            (None, None) => Ok(()),
+            _ => Err(format!(
+                "direct presence mismatch: source={source:?} unified={unified:?}"
+            )),
+        },
+        "fixed_point_dollars" | "fixed_point_count" | "string_to_f64" => {
+            if source_present != unified_present {
+                return Err(format!(
+                    "{transform} presence mismatch: source={source:?} unified={unified:?}"
+                ));
+            }
+            if !source_present {
+                return Ok(());
+            }
+            let parsed = source
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse::<f64>().ok())
+                .or_else(|| source.and_then(|v| v.as_f64()))
+                .ok_or_else(|| format!("{transform}: source not parseable: {source:?}"))?;
+            let actual = unified
+                .and_then(|v| v.as_f64())
+                .ok_or_else(|| format!("{transform}: unified not f64: {unified:?}"))?;
+            if (parsed - actual).abs() < 1e-9 {
+                Ok(())
+            } else {
+                Err(format!(
+                    "{transform} value mismatch: parsed_source={parsed} unified={actual}"
+                ))
+            }
+        }
+        "parse_datetime" => {
+            if source_present != unified_present {
+                return Err(format!(
+                    "parse_datetime presence mismatch: source={source:?} unified={unified:?}"
+                ));
+            }
+            if !source_present {
+                return Ok(());
+            }
+            let s = source
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| format!("parse_datetime: source not string: {source:?}"))?;
+            let u = unified
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| format!("parse_datetime: unified not string: {unified:?}"))?;
+            let parsed_s = chrono::DateTime::parse_from_rfc3339(s)
+                .map_err(|e| format!("parse_datetime: source not RFC3339: {e}"))?;
+            let parsed_u = chrono::DateTime::parse_from_rfc3339(u)
+                .map_err(|e| format!("parse_datetime: unified not RFC3339: {e}"))?;
+            if parsed_s.timestamp() == parsed_u.timestamp() {
+                Ok(())
+            } else {
+                Err(format!("parse_datetime mismatch: source={s} unified={u}"))
+            }
+        }
+        "enum_remap" | "first_non_null" => {
+            if source_present && !unified_present {
+                Err(format!(
+                    "{transform}: source present but unified is null: source={source:?}"
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        other => Err(format!("unknown transform `{other}`")),
+    }
+}
+
+/// Walk a mapping YAML and verify every `<exchange_key>:`-sourced field's
+/// value in `unified` matches the value at the declared `$ref` in `fixture`,
+/// modulo the declared transform.
+///
+/// Returns `(checked, violations)`. Use [`assert_mapping_contract`] if you
+/// just want to panic on any drift.
+pub fn verify_mapping_contract(
+    fixture: &Value,
+    unified: &Value,
+    mapping: &serde_yaml::Value,
+    exchange_key: &str,
+) -> (usize, Vec<String>) {
+    let fields = mapping
+        .get("fields")
+        .and_then(|v| v.as_sequence())
+        .expect("mapping has fields[]");
+
+    let mut violations: Vec<String> = Vec::new();
+    let mut checked = 0usize;
+
+    for field in fields {
+        let name = match field.get("name").and_then(|v| v.as_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if field.get("synthetic").is_some() && field.get("sources").is_none() {
+            continue;
+        }
+        let src = match field.get("sources").and_then(|s| s.get(exchange_key)) {
+            Some(s) => s,
+            None => continue,
+        };
+        if src.get("omitted").and_then(|v| v.as_bool()) == Some(true) {
+            continue;
+        }
+        if src.get("synthetic").is_some() {
+            continue;
+        }
+        let reference = match src.get("ref").and_then(|v| v.as_str()) {
+            Some(r) => r,
+            None => {
+                violations.push(format!(
+                    "[{name}] {exchange_key} entry has no `ref:`, `synthetic:`, or `omitted:`"
+                ));
+                continue;
+            }
+        };
+        let transform = src
+            .get("transform")
+            .and_then(|v| v.as_str())
+            .unwrap_or("direct");
+
+        let source_value = lookup_in_fixture(fixture, reference);
+        let unified_value = unified.get(name);
+
+        if let Err(reason) = check_field(transform, source_value, unified_value) {
+            violations.push(format!(
+                "[{name}] ref={} transform={transform}: {reason}",
+                reference.strip_prefix(REF_PREFIX).unwrap_or(reference)
+            ));
+        }
+        checked += 1;
+    }
+
+    (checked, violations)
+}
+
+/// Run [`verify_mapping_contract`] and panic with a structured error on any
+/// violation. Also panics if no fields were exercised at all (which would
+/// usually mean the fixture or mapping is wrong).
+pub fn assert_mapping_contract(
+    fixture: &Value,
+    unified: &Value,
+    mapping: &serde_yaml::Value,
+    exchange_key: &str,
+) {
+    let (checked, violations) = verify_mapping_contract(fixture, unified, mapping, exchange_key);
+    if !violations.is_empty() {
+        panic!(
+            "{} of {} sourced fields drifted between schema/mappings/market.yaml and the \
+             actual {exchange_key} parse_market — fix the YAML or fix the code:\n  {}",
+            violations.len(),
+            checked,
+            violations.join("\n  ")
+        );
+    }
+    assert!(
+        checked > 0,
+        "no {exchange_key}-sourced fields exercised — fixture or mapping wrong"
+    );
+}

--- a/engine/exchanges/kalshi/Cargo.toml
+++ b/engine/exchanges/kalshi/Cargo.toml
@@ -32,7 +32,7 @@ pkcs8 = { version = "0.10", features = ["pem"] }
 pkcs1 = { version = "0.7", features = ["pem"] }
 
 [dev-dependencies]
+px-core = { workspace = true, features = ["http", "simd-json", "test-support"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 rand = "0.8"
 wiremock = "0.6"
-serde_yaml = "0.9"

--- a/engine/exchanges/kalshi/tests/mapping_contract.rs
+++ b/engine/exchanges/kalshi/tests/mapping_contract.rs
@@ -1,147 +1,25 @@
 //! Mapping contract test for Kalshi → OpenPX `Market`.
 //!
-//! Loads `schema/mappings/market.yaml` from the workspace root and the
-//! committed Kalshi fixture, mocks Kalshi's `/markets/<id>` endpoint, calls
-//! `fetch_market`, then walks the YAML and asserts the actual code's output
-//! matches what each `kalshi:` source claims.
-//!
-//! Behavioral equivalence — the test verifies that *given a real fixture*, the
-//! unified `Market` field equals the fixture's value at the declared source
-//! path (after the declared transform). It does NOT prove the code reads
-//! exactly that path at runtime; that would require source-level
-//! instrumentation. In practice, sentinel values in the fixture make any
-//! source-path swap detectable.
+//! Mocks Kalshi's `/markets/<id>` endpoint with the committed fixture, calls
+//! `fetch_market`, and hands the result to the shared harness in
+//! `px_core::test_support` which walks `schema/mappings/market.yaml` and
+//! verifies every `kalshi:` source matches the parsed unified value.
 
 use std::fs;
 use std::path::PathBuf;
 
-use px_core::Exchange;
+use px_core::{
+    test_support::{assert_mapping_contract, load_mapping},
+    Exchange,
+};
 use px_exchange_kalshi::{Kalshi, KalshiConfig};
 use serde_json::Value;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-const REF_PREFIX: &str = "#/components/schemas/Market/properties/";
-
-fn workspace_root() -> PathBuf {
-    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    p.pop();
-    p.pop();
-    p.pop();
-    p
-}
-
-fn load_mapping() -> serde_yaml::Value {
-    let p = workspace_root().join("schema/mappings/market.yaml");
-    serde_yaml::from_str(&fs::read_to_string(&p).expect("read mapping yaml"))
-        .expect("parse mapping yaml")
-}
-
 fn load_fixture() -> Value {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/market.json");
     serde_json::from_str(&fs::read_to_string(&p).expect("read fixture")).expect("parse fixture")
-}
-
-fn ref_to_field(reference: &str) -> Option<&str> {
-    reference.strip_prefix(REF_PREFIX)
-}
-
-fn lookup_in_fixture<'a>(fixture: &'a Value, reference: &str) -> Option<&'a Value> {
-    fixture.get(ref_to_field(reference)?)
-}
-
-/// Approximate equivalence between a source value (from the upstream fixture)
-/// and a unified value (from serialized openpx Market), modulo the declared
-/// transform. Returns `Ok(())` on match or `Err(reason)` on mismatch.
-fn check_field(
-    transform: &str,
-    source: Option<&Value>,
-    unified: Option<&Value>,
-) -> Result<(), String> {
-    let source_present = source.is_some_and(|v| !v.is_null());
-    let unified_present = unified.is_some_and(|v| !v.is_null());
-
-    match transform {
-        "direct" => {
-            // Direct: same value, modulo numeric int/float widening.
-            match (source, unified) {
-                (Some(s), Some(u)) if s == u => Ok(()),
-                (Some(s), Some(u)) => match (s.as_f64(), u.as_f64()) {
-                    (Some(a), Some(b)) if (a - b).abs() < 1e-9 => Ok(()),
-                    _ => Err(format!("direct mismatch: source={s:?} unified={u:?}")),
-                },
-                (None, None) => Ok(()),
-                _ => Err(format!(
-                    "direct presence mismatch: source={source:?} unified={unified:?}"
-                )),
-            }
-        }
-        "fixed_point_dollars" | "fixed_point_count" | "string_to_f64" => {
-            if source_present != unified_present {
-                return Err(format!(
-                    "{transform} presence mismatch: source={source:?} unified={unified:?}"
-                ));
-            }
-            if !source_present {
-                return Ok(());
-            }
-            let parsed = source
-                .and_then(|v| v.as_str())
-                .and_then(|s| s.parse::<f64>().ok())
-                .or_else(|| source.and_then(|v| v.as_f64()))
-                .ok_or_else(|| format!("{transform}: source not parseable as f64: {source:?}"))?;
-            let actual = unified
-                .and_then(|v| v.as_f64())
-                .ok_or_else(|| format!("{transform}: unified not f64: {unified:?}"))?;
-            if (parsed - actual).abs() < 1e-9 {
-                Ok(())
-            } else {
-                Err(format!(
-                    "{transform} value mismatch: parsed_source={parsed} unified={actual}"
-                ))
-            }
-        }
-        "parse_datetime" => {
-            if source_present != unified_present {
-                return Err(format!(
-                    "parse_datetime presence mismatch: source={source:?} unified={unified:?}"
-                ));
-            }
-            if !source_present {
-                return Ok(());
-            }
-            let s = source
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| format!("parse_datetime: source not string: {source:?}"))?;
-            let u = unified
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| format!("parse_datetime: unified not string: {unified:?}"))?;
-            let parsed_s = chrono::DateTime::parse_from_rfc3339(s)
-                .map_err(|e| format!("parse_datetime: source not RFC3339: {e}"))?;
-            let parsed_u = chrono::DateTime::parse_from_rfc3339(u)
-                .map_err(|e| format!("parse_datetime: unified not RFC3339: {e}"))?;
-            if parsed_s.timestamp() == parsed_u.timestamp() {
-                Ok(())
-            } else {
-                Err(format!(
-                    "parse_datetime value mismatch: source={s} unified={u}"
-                ))
-            }
-        }
-        "enum_remap" | "first_non_null" => {
-            // We can't mechanically verify enum mappings or fallback semantics
-            // without per-field knowledge. Settle for presence-equivalence:
-            // if source has a non-null value, unified should have one too.
-            if source_present && !unified_present {
-                Err(format!(
-                    "{transform}: source present but unified is null: source={source:?}"
-                ))
-            } else {
-                Ok(())
-            }
-        }
-        other => Err(format!("unknown transform `{other}`")),
-    }
 }
 
 #[tokio::test]
@@ -173,75 +51,6 @@ async fn yaml_contract_for_kalshi_market() {
         .expect("fetch_market should succeed against mock");
 
     let unified = serde_json::to_value(&market).expect("serialize Market");
-
-    let mapping = load_mapping();
-    let fields = mapping
-        .get("fields")
-        .and_then(|v| v.as_sequence())
-        .expect("mapping has fields[]");
-
-    let mut violations: Vec<String> = Vec::new();
-    let mut checked = 0usize;
-
-    for field in fields {
-        let name = match field.get("name").and_then(|v| v.as_str()) {
-            Some(n) => n,
-            None => continue,
-        };
-        if field.get("synthetic").is_some() && field.get("sources").is_none() {
-            continue;
-        }
-        let src = match field.get("sources").and_then(|s| s.get("kalshi")) {
-            Some(s) => s,
-            None => continue,
-        };
-        if src.get("omitted").and_then(|v| v.as_bool()) == Some(true) {
-            continue;
-        }
-        if src.get("synthetic").is_some() {
-            continue;
-        }
-        let reference = match src.get("ref").and_then(|v| v.as_str()) {
-            Some(r) => r,
-            None => {
-                violations.push(format!(
-                    "[{name}] kalshi entry has no `ref:`, `synthetic:`, or `omitted:`"
-                ));
-                continue;
-            }
-        };
-        let transform = src
-            .get("transform")
-            .and_then(|v| v.as_str())
-            .unwrap_or("direct");
-
-        let source_value = lookup_in_fixture(&fixture, reference);
-        let unified_value = unified.get(name);
-
-        match check_field(transform, source_value, unified_value) {
-            Ok(()) => {}
-            Err(reason) => {
-                violations.push(format!(
-                    "[{name}] ref={} transform={transform}: {reason}",
-                    reference.strip_prefix(REF_PREFIX).unwrap_or(reference)
-                ));
-            }
-        }
-        checked += 1;
-    }
-
-    if !violations.is_empty() {
-        panic!(
-            "{} of {} sourced fields drifted between schema/mappings/market.yaml and the \
-             actual Kalshi parse_market — fix the YAML or fix the code:\n  {}",
-            violations.len(),
-            checked,
-            violations.join("\n  ")
-        );
-    }
-
-    assert!(
-        checked > 0,
-        "no kalshi-sourced fields exercised — fixture or mapping wrong"
-    );
+    let mapping = load_mapping(env!("CARGO_MANIFEST_DIR"), "market");
+    assert_mapping_contract(&fixture, &unified, &mapping, "kalshi");
 }

--- a/engine/exchanges/polymarket/Cargo.toml
+++ b/engine/exchanges/polymarket/Cargo.toml
@@ -34,6 +34,6 @@ hmac = "0.12"
 sha2 = "0.10"
 
 [dev-dependencies]
+px-core = { workspace = true, features = ["http", "simd-json", "test-support"] }
 tokio = { workspace = true, features = ["test-util"] }
 wiremock = "0.6"
-serde_yaml = "0.9"

--- a/engine/exchanges/polymarket/tests/mapping_contract.rs
+++ b/engine/exchanges/polymarket/tests/mapping_contract.rs
@@ -1,132 +1,25 @@
 //! Mapping contract test for Polymarket → OpenPX `Market`.
 //!
-//! Loads `schema/mappings/market.yaml` from the workspace root and the
-//! committed Polymarket gamma fixture, mocks `/markets?id=<id>` on the gamma
-//! API, calls `fetch_market`, then walks the YAML and asserts the actual
-//! code's output matches what each `polymarket:` source claims.
-//!
-//! The same caveat as Kalshi: this is *behavioral equivalence* against the
-//! fixture — sentinel values surface any source-path swap, but the test does
-//! not statically prove the code reads a specific path at runtime.
+//! Mocks the gamma `/markets?id=<id>` endpoint with the committed fixture,
+//! calls `fetch_market`, and hands the result to the shared harness in
+//! `px_core::test_support` which walks `schema/mappings/market.yaml` and
+//! verifies every `polymarket:` source matches the parsed unified value.
 
 use std::fs;
 use std::path::PathBuf;
 
-use px_core::Exchange;
+use px_core::{
+    test_support::{assert_mapping_contract, load_mapping},
+    Exchange,
+};
 use px_exchange_polymarket::{Polymarket, PolymarketConfig};
 use serde_json::Value;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-const REF_PREFIX: &str = "#/components/schemas/Market/properties/";
-
-fn workspace_root() -> PathBuf {
-    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    p.pop();
-    p.pop();
-    p.pop();
-    p
-}
-
-fn load_mapping() -> serde_yaml::Value {
-    let p = workspace_root().join("schema/mappings/market.yaml");
-    serde_yaml::from_str(&fs::read_to_string(&p).expect("read mapping yaml"))
-        .expect("parse mapping yaml")
-}
-
 fn load_fixture() -> Value {
     let p = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/market.json");
     serde_json::from_str(&fs::read_to_string(&p).expect("read fixture")).expect("parse fixture")
-}
-
-fn lookup_in_fixture<'a>(fixture: &'a Value, reference: &str) -> Option<&'a Value> {
-    fixture.get(reference.strip_prefix(REF_PREFIX)?)
-}
-
-/// Behavioral equivalence between an upstream value (from the fixture) and a
-/// unified value (from the serialized openpx Market), modulo the declared
-/// transform. Returns `Ok(())` on match or `Err(reason)` on mismatch.
-fn check_field(
-    transform: &str,
-    source: Option<&Value>,
-    unified: Option<&Value>,
-) -> Result<(), String> {
-    let source_present = source.is_some_and(|v| !v.is_null());
-    let unified_present = unified.is_some_and(|v| !v.is_null());
-
-    match transform {
-        "direct" => match (source, unified) {
-            (Some(s), Some(u)) if s == u => Ok(()),
-            (Some(s), Some(u)) => match (s.as_f64(), u.as_f64()) {
-                (Some(a), Some(b)) if (a - b).abs() < 1e-9 => Ok(()),
-                _ => Err(format!("direct mismatch: source={s:?} unified={u:?}")),
-            },
-            (None, None) => Ok(()),
-            _ => Err(format!(
-                "direct presence mismatch: source={source:?} unified={unified:?}"
-            )),
-        },
-        "fixed_point_dollars" | "fixed_point_count" | "string_to_f64" => {
-            if source_present != unified_present {
-                return Err(format!(
-                    "{transform} presence mismatch: source={source:?} unified={unified:?}"
-                ));
-            }
-            if !source_present {
-                return Ok(());
-            }
-            let parsed = source
-                .and_then(|v| v.as_str())
-                .and_then(|s| s.parse::<f64>().ok())
-                .or_else(|| source.and_then(|v| v.as_f64()))
-                .ok_or_else(|| format!("{transform}: source not parseable: {source:?}"))?;
-            let actual = unified
-                .and_then(|v| v.as_f64())
-                .ok_or_else(|| format!("{transform}: unified not f64: {unified:?}"))?;
-            if (parsed - actual).abs() < 1e-9 {
-                Ok(())
-            } else {
-                Err(format!(
-                    "{transform} value mismatch: parsed_source={parsed} unified={actual}"
-                ))
-            }
-        }
-        "parse_datetime" => {
-            if source_present != unified_present {
-                return Err(format!(
-                    "parse_datetime presence mismatch: source={source:?} unified={unified:?}"
-                ));
-            }
-            if !source_present {
-                return Ok(());
-            }
-            let s = source
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| format!("parse_datetime: source not string: {source:?}"))?;
-            let u = unified
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| format!("parse_datetime: unified not string: {unified:?}"))?;
-            let parsed_s = chrono::DateTime::parse_from_rfc3339(s)
-                .map_err(|e| format!("parse_datetime: source not RFC3339: {e}"))?;
-            let parsed_u = chrono::DateTime::parse_from_rfc3339(u)
-                .map_err(|e| format!("parse_datetime: unified not RFC3339: {e}"))?;
-            if parsed_s.timestamp() == parsed_u.timestamp() {
-                Ok(())
-            } else {
-                Err(format!("parse_datetime mismatch: source={s} unified={u}"))
-            }
-        }
-        "enum_remap" | "first_non_null" => {
-            if source_present && !unified_present {
-                Err(format!(
-                    "{transform}: source present but unified is null: source={source:?}"
-                ))
-            } else {
-                Ok(())
-            }
-        }
-        other => Err(format!("unknown transform `{other}`")),
-    }
 }
 
 #[tokio::test]
@@ -158,75 +51,6 @@ async fn yaml_contract_for_polymarket_market() {
         .expect("fetch_market should succeed against mock");
 
     let unified = serde_json::to_value(&market).expect("serialize Market");
-
-    let mapping = load_mapping();
-    let fields = mapping
-        .get("fields")
-        .and_then(|v| v.as_sequence())
-        .expect("mapping has fields[]");
-
-    let mut violations: Vec<String> = Vec::new();
-    let mut checked = 0usize;
-
-    for field in fields {
-        let name = match field.get("name").and_then(|v| v.as_str()) {
-            Some(n) => n,
-            None => continue,
-        };
-        if field.get("synthetic").is_some() && field.get("sources").is_none() {
-            continue;
-        }
-        let src = match field.get("sources").and_then(|s| s.get("polymarket")) {
-            Some(s) => s,
-            None => continue,
-        };
-        if src.get("omitted").and_then(|v| v.as_bool()) == Some(true) {
-            continue;
-        }
-        if src.get("synthetic").is_some() {
-            continue;
-        }
-        let reference = match src.get("ref").and_then(|v| v.as_str()) {
-            Some(r) => r,
-            None => {
-                violations.push(format!(
-                    "[{name}] polymarket entry has no `ref:`, `synthetic:`, or `omitted:`"
-                ));
-                continue;
-            }
-        };
-        let transform = src
-            .get("transform")
-            .and_then(|v| v.as_str())
-            .unwrap_or("direct");
-
-        let source_value = lookup_in_fixture(&fixture, reference);
-        let unified_value = unified.get(name);
-
-        match check_field(transform, source_value, unified_value) {
-            Ok(()) => {}
-            Err(reason) => {
-                violations.push(format!(
-                    "[{name}] ref={} transform={transform}: {reason}",
-                    reference.strip_prefix(REF_PREFIX).unwrap_or(reference)
-                ));
-            }
-        }
-        checked += 1;
-    }
-
-    if !violations.is_empty() {
-        panic!(
-            "{} of {} sourced fields drifted between schema/mappings/market.yaml and the \
-             actual Polymarket parse_market — fix the YAML or fix the code:\n  {}",
-            violations.len(),
-            checked,
-            violations.join("\n  ")
-        );
-    }
-
-    assert!(
-        checked > 0,
-        "no polymarket-sourced fields exercised — fixture or mapping wrong"
-    );
+    let mapping = load_mapping(env!("CARGO_MANIFEST_DIR"), "market");
+    assert_mapping_contract(&fixture, &unified, &mapping, "polymarket");
 }

--- a/tools/mapping_lib.py
+++ b/tools/mapping_lib.py
@@ -1,0 +1,55 @@
+"""Shared primitives for the mapping-system tools.
+
+Both `validate_mappings.py` (the gate) and `render_mappings.py` (the renderer)
+operate on the same files — `schema/mappings/*.yaml`,
+`schema/openpx.schema.json`, and `schema/upstream/*` — so they share the file
+loading and JSON-pointer ref-resolution logic.
+
+The semantic surfaces (type compatibility for validation, type-label display
+for rendering) stay in their respective tools because they have different
+concerns: validate cares about whether `transform=direct` is sound, render
+cares about how to display the type to a human.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_yaml(path: Path) -> Any:
+    return yaml.safe_load(path.read_text())
+
+
+def load_schema_definitions(schema_path: Path) -> dict[str, Any]:
+    """Return the `definitions` (or `$defs`) map from an openpx JSON Schema."""
+    schema = json.loads(schema_path.read_text())
+    return schema.get("definitions") or schema.get("$defs") or {}
+
+
+def resolve_ref(spec: dict[str, Any], ref: str) -> dict[str, Any] | None:
+    """Resolve a JSON-pointer-style ref like
+    `#/components/schemas/Market/properties/ticker` against `spec`. Returns
+    None if any segment is missing."""
+    if not ref.startswith("#/"):
+        return None
+    cur: Any = spec
+    for part in ref[2:].split("/"):
+        part = part.replace("~1", "/").replace("~0", "~")
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    return cur if isinstance(cur, dict) else None
+
+
+def normalize_type(t: Any) -> set[str]:
+    """Return the set of non-null types for a JSON-Schema/OpenAPI `type` field
+    (which can be a string or a list)."""
+    if isinstance(t, list):
+        return {x for x in t if x and x != "null"}
+    if isinstance(t, str):
+        return {t} if t != "null" else set()
+    return set()

--- a/tools/render_mappings.py
+++ b/tools/render_mappings.py
@@ -11,34 +11,16 @@ from the mapping YAML, source types from the cached upstream specs.
 """
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 from typing import Any
 
-import yaml
+from mapping_lib import load_schema_definitions, load_yaml, resolve_ref
 
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMA = ROOT / "schema" / "openpx.schema.json"
 MAPPINGS_DIR = ROOT / "schema" / "mappings"
 OUTPUT_DIR = ROOT / "docs" / "api" / "mappings"
-
-
-def load_yaml(p: Path) -> Any:
-    return yaml.safe_load(p.read_text())
-
-
-def resolve_ref(spec: dict[str, Any], ref: str) -> dict[str, Any] | None:
-    if not ref.startswith("#/"):
-        return None
-    cur: Any = spec
-    for part in ref[2:].split("/"):
-        part = part.replace("~1", "/").replace("~0", "~")
-        if isinstance(cur, dict) and part in cur:
-            cur = cur[part]
-        else:
-            return None
-    return cur if isinstance(cur, dict) else None
 
 
 def short_ref(ref: str) -> str:
@@ -258,8 +240,7 @@ def render_table(mapping: dict[str, Any], unified: dict[str, Any]) -> str:
 
 
 def main() -> int:
-    schema = json.loads(SCHEMA.read_text())
-    defs = schema.get("definitions") or schema.get("$defs") or {}
+    defs = load_schema_definitions(SCHEMA)
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
     files = sorted(MAPPINGS_DIR.glob("*.yaml"))

--- a/tools/validate_mappings.py
+++ b/tools/validate_mappings.py
@@ -16,12 +16,11 @@ Usage:
 """
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 from typing import Any
 
-import yaml
+from mapping_lib import load_schema_definitions, load_yaml, normalize_type, resolve_ref
 
 ROOT = Path(__file__).resolve().parent.parent
 SCHEMA = ROOT / "schema" / "openpx.schema.json"
@@ -38,45 +37,17 @@ DIRECT_COMPATIBLE: dict[str, set[str]] = {
 }
 
 
-def load_yaml(p: Path) -> Any:
-    return yaml.safe_load(p.read_text())
-
-
 def load_openpx_unified(type_name: str) -> dict[str, Any]:
-    schema = json.loads(SCHEMA.read_text())
-    defs = schema.get("definitions") or schema.get("$defs") or {}
+    defs = load_schema_definitions(SCHEMA)
     if type_name not in defs:
         sys.exit(f"openpx.schema.json has no definition for {type_name!r}")
     return defs[type_name]
 
 
-def resolve_ref(spec: dict[str, Any], ref: str) -> dict[str, Any] | None:
-    """Resolve a JSON-pointer-style ref like '#/components/schemas/Market/properties/ticker'."""
-    if not ref.startswith("#/"):
-        return None
-    cur: Any = spec
-    for part in ref[2:].split("/"):
-        part = part.replace("~1", "/").replace("~0", "~")
-        if isinstance(cur, dict) and part in cur:
-            cur = cur[part]
-        else:
-            return None
-    return cur if isinstance(cur, dict) else None
-
-
-def _normalize_type(t: Any) -> set[str]:
-    """Return the set of non-null types for an OpenAPI/JSON-Schema type field."""
-    if isinstance(t, list):
-        return {x for x in t if x and x != "null"}
-    if isinstance(t, str):
-        return {t} if t != "null" else set()
-    return set()
-
-
 def _spec_type(node: dict[str, Any]) -> set[str]:
     """Best-effort type extraction from a resolved OpenAPI property node."""
     if "type" in node:
-        return _normalize_type(node["type"])
+        return normalize_type(node["type"])
     # OpenAPI nullable: true with $ref means the ref's type
     if "$ref" in node:
         return {"$ref"}
@@ -90,7 +61,7 @@ def _spec_type(node: dict[str, Any]) -> set[str]:
 
 def _unified_type(node: dict[str, Any]) -> set[str]:
     if "type" in node:
-        return _normalize_type(node["type"])
+        return normalize_type(node["type"])
     if "allOf" in node:
         for sub in node["allOf"]:
             if isinstance(sub, dict) and "$ref" in sub:


### PR DESCRIPTION
## Summary

The mapping-system contract surface is **unchanged**; this is pure internal dedupe across two pairs of copy-pasted files. Both wins identified in the audit, in one PR.

### Win 1 — shared Rust test harness (`px-core::test_support`)
Both `engine/exchanges/{kalshi,polymarket}/tests/mapping_contract.rs` had copy-pasted the entire transform vocabulary (`direct`, `fixed_point_dollars`, `fixed_point_count`, `string_to_f64`, `parse_datetime`, `enum_remap`, `first_non_null`), the `lookup_in_fixture` helper, and the walk-mapping-and-verify loop. A new `test-support` feature on `px-core` gates a single home for all of it. Kalshi and Polymarket can no longer drift on what any transform means.

- Per-exchange test files shrink from **247 / 232 lines → 56 each**
- Each exchange now picks up `px-core` as a dev-dep with `test-support` enabled; the direct `serde_yaml = "0.9"` dev-dep is dropped (it lives in px-core under the feature flag now)
- The shared module is `cfg(feature = "test-support")` so it's not compiled into release builds

### Win 2 — shared Python `tools/mapping_lib.py`
`validate_mappings.py` and `render_mappings.py` had each copy-pasted `resolve_ref`, the YAML loader, and the schema-definitions accessor. Now they import from a 55-line `mapping_lib.py`.

- `validate_mappings.py`: 292 → 262 lines
- `render_mappings.py`: 288 → 269 lines
- Type-label rendering (render-specific) and type-compatibility validation (validate-specific) stay in their respective tools — they have different concerns

## Why this is the right scope

What I deliberately did **not** do (per the audit recommendation):
- Did not merge `validate_mappings.py` + `render_mappings.py` into one tool — gate-vs-generator are distinct concerns
- Did not consolidate the transform vocabulary (`fixed_point_dollars` / `fixed_point_count` / `string_to_f64`) — the named set is the contract surface that the YAML, validator, and runtime test all key off of
- Did not move per-type YAML into a single file — coordinate-driven means per-type granularity

## Net change

| | Before | After |
|---|---|---|
| `kalshi/tests/mapping_contract.rs` | 247 | 56 |
| `polymarket/tests/mapping_contract.rs` | 232 | 56 |
| `px-core::test_support` | — | 222 (new) |
| `validate_mappings.py` | 292 | 262 |
| `render_mappings.py` | 288 | 269 |
| `mapping_lib.py` | — | 55 (new) |
| **Total** | **1,059** | **920** |

Net: **−139 lines**, plus the structural win — the transform vocab and ref-resolution semantics each live in exactly one place.

## Test plan

- [x] `cargo test -p px-exchange-kalshi --test mapping_contract` — ok
- [x] `cargo test -p px-exchange-polymarket --test mapping_contract` — ok
- [x] `cargo test --workspace` — exit 0
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `python tools/validate_mappings.py` — PASS, same coverage report
- [x] `python tools/render_mappings.py` — same 9,538 byte `market.mdx` output
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)