### PR TITLE
refactor(api)!: lean fetch_trades — 5-field request, 10-field response

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Validate exchange→openpx field mappings
         run: just check-mappings
       - name: Check generated files are in sync
-        run: git diff --exit-code schema/openpx.schema.json sdks/python/python/openpx/_models.py sdks/typescript/types/models.d.ts docs/llms.txt docs/api/ docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml
+        run: git diff --exit-code schema/openpx.schema.json sdks/python/python/openpx/_models.py sdks/typescript/types/models.d.ts docs/llms.txt docs/api/ docs/schemas/mappings/ docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml
       # Smoke checks: a regen can produce a syntactically degenerate file
       # (e.g. an empty stub) that drifts undetectably under git diff alone.
       # PR #26 hid for an indeterminate amount of time because models.d.ts

--- a/docs/api/trades/fetch-trades.mdx
+++ b/docs/api/trades/fetch-trades.mdx
@@ -4,4 +4,6 @@ sidebarTitle: "Fetch trades"
 openapi: /openpx.openapi.yaml GET /v1/trades/fetch_trades
 ---
 
-Fetch a paginated tape of recent public trades for a market outcome.
+Fetch a paginated tape of recent public trades for a market.
+Both Yes and No outcomes' trades are returned interleaved; consumers
+distinguish via `MarketTrade.outcome`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -106,7 +106,8 @@
               "schemas/mappings/market",
               "schemas/mappings/event",
               "schemas/mappings/series",
-              "schemas/mappings/orderbook"
+              "schemas/mappings/orderbook",
+              "schemas/mappings/trade"
             ]
           }
         ]

--- a/docs/openpx.asyncapi.yaml
+++ b/docs/openpx.asyncapi.yaml
@@ -1086,25 +1086,28 @@ components:
       - all
       type: string
     MarketTrade:
-      description: 'Normalized public market trade, suitable for "tape" UIs.
-
-
-        - `price` is normalized to [0.0, 1.0] across all exchanges. - `timestamp` is the exchange-provided trade timestamp
-        (UTC).'
+      description: "Normalized public market trade, suitable for \"tape\" UIs.\n\n- `price` is normalized to [0.0, 1.0]; anchored\
+        \ to the Yes side on binary markets \u2014 use `no_price` for the No-side reference. - `aggressor_side` is \"buy\"\
+        \ / \"sell\" relative to the Yes side on binary markets \u2014 \"buy\" means upward pressure on Yes, \"sell\" downward.\
+        \ - `exchange_ts` is the upstream-provided trade timestamp. - `openpx_ts` is wall-clock when OpenPX served the response."
       properties:
         aggressor_side:
           type:
           - string
           - 'null'
+        exchange_ts:
+          format: date-time
+          type: string
         id:
-          type:
-          - string
-          - 'null'
+          type: string
         no_price:
           format: double
           type:
           - number
           - 'null'
+        openpx_ts:
+          format: date-time
+          type: string
         outcome:
           type:
           - string
@@ -1112,23 +1115,10 @@ components:
         price:
           format: double
           type: number
-        side:
-          type:
-          - string
-          - 'null'
         size:
           format: double
           type: number
-        source_channel:
-          type: string
         taker_address:
-          type:
-          - string
-          - 'null'
-        timestamp:
-          format: date-time
-          type: string
-        tx_hash:
           type:
           - string
           - 'null'
@@ -1138,10 +1128,11 @@ components:
           - number
           - 'null'
       required:
+      - exchange_ts
+      - id
+      - openpx_ts
       - price
       - size
-      - source_channel
-      - timestamp
       title: MarketTrade
       type: object
     MarketType:
@@ -1737,51 +1728,38 @@ components:
       title: SportResult
       type: object
     TradesRequest:
-      description: Request for fetching recent public trades ("tape") for a market outcome.
+      description: "Request for fetching recent public trades (\"tape\") for a market.\n\n`asset_id` is the market identifier\
+        \ \u2014 Kalshi market ticker or Polymarket Gamma slug. Both Yes and No outcomes' trades are returned interleaved;\
+        \ use `MarketTrade.outcome` to distinguish."
       properties:
+        asset_id:
+          type: string
         cursor:
-          description: Opaque pagination cursor from a previous response.
+          description: Opaque cursor from a prior response.
           type:
           - string
           - 'null'
         end_ts:
-          description: Unix seconds (inclusive)
+          description: Unix seconds (inclusive upper bound).
           format: int64
           type:
           - integer
           - 'null'
         limit:
-          description: Max number of trades to return (exchange-specific caps may apply).
+          description: Max trades to return. Capped per exchange (Kalshi 1000, Polymarket 500).
           format: uint
           minimum: 0.0
           type:
           - integer
           - 'null'
-        market_ref:
-          description: Optional alternate market identifier for trade endpoints (e.g., Polymarket conditionId). When provided,
-            exchanges should prefer this over `market_ticker`.
-          type:
-          - string
-          - 'null'
-        market_ticker:
-          description: Exchange-native market identifier.
-          type: string
-        outcome:
-          type:
-          - string
-          - 'null'
         start_ts:
-          description: Unix seconds (inclusive)
+          description: Unix seconds (inclusive lower bound).
           format: int64
           type:
           - integer
           - 'null'
-        token_id:
-          type:
-          - string
-          - 'null'
       required:
-      - market_ticker
+      - asset_id
       title: TradesRequest
       type: object
     WsUpdate:

--- a/docs/openpx.openapi.yaml
+++ b/docs/openpx.openapi.yaml
@@ -360,9 +360,18 @@ paths:
       tags:
       - Trades
       summary: Fetch trades
-      description: Fetch a paginated tape of recent public trades for a market outcome.
+      description: 'Fetch a paginated tape of recent public trades for a market.
+
+        Both Yes and No outcomes'' trades are returned interleaved; consumers
+
+        distinguish via `MarketTrade.outcome`.'
       operationId: fetch_trades
       parameters:
+      - name: asset_id
+        in: query
+        required: true
+        schema:
+          type: string
       - name: cursor
         in: query
         required: false
@@ -370,7 +379,7 @@ paths:
           type:
           - string
           - 'null'
-        description: Opaque pagination cursor from a previous response.
+        description: Opaque cursor from a prior response.
       - name: end_ts
         in: query
         required: false
@@ -379,7 +388,7 @@ paths:
           type:
           - integer
           - 'null'
-        description: Unix seconds (inclusive)
+        description: Unix seconds (inclusive upper bound).
       - name: limit
         in: query
         required: false
@@ -389,29 +398,7 @@ paths:
           type:
           - integer
           - 'null'
-        description: Max number of trades to return (exchange-specific caps may apply).
-      - name: market_ref
-        in: query
-        required: false
-        schema:
-          type:
-          - string
-          - 'null'
-        description: Optional alternate market identifier for trade endpoints (e.g., Polymarket conditionId). When provided,
-          exchanges should prefer this over `market_ticker`.
-      - name: market_ticker
-        in: query
-        required: true
-        schema:
-          type: string
-        description: Exchange-native market identifier.
-      - name: outcome
-        in: query
-        required: false
-        schema:
-          type:
-          - string
-          - 'null'
+        description: Max trades to return. Capped per exchange (Kalshi 1000, Polymarket 500).
       - name: start_ts
         in: query
         required: false
@@ -420,14 +407,7 @@ paths:
           type:
           - integer
           - 'null'
-        description: Unix seconds (inclusive)
-      - name: token_id
-        in: query
-        required: false
-        schema:
-          type:
-          - string
-          - 'null'
+        description: Unix seconds (inclusive lower bound).
       responses:
         '200':
           description: Success.
@@ -1360,25 +1340,28 @@ components:
       - all
       type: string
     MarketTrade:
-      description: 'Normalized public market trade, suitable for "tape" UIs.
-
-
-        - `price` is normalized to [0.0, 1.0] across all exchanges. - `timestamp` is the exchange-provided trade timestamp
-        (UTC).'
+      description: "Normalized public market trade, suitable for \"tape\" UIs.\n\n- `price` is normalized to [0.0, 1.0]; anchored\
+        \ to the Yes side on binary markets \u2014 use `no_price` for the No-side reference. - `aggressor_side` is \"buy\"\
+        \ / \"sell\" relative to the Yes side on binary markets \u2014 \"buy\" means upward pressure on Yes, \"sell\" downward.\
+        \ - `exchange_ts` is the upstream-provided trade timestamp. - `openpx_ts` is wall-clock when OpenPX served the response."
       properties:
         aggressor_side:
           type:
           - string
           - 'null'
+        exchange_ts:
+          format: date-time
+          type: string
         id:
-          type:
-          - string
-          - 'null'
+          type: string
         no_price:
           format: double
           type:
           - number
           - 'null'
+        openpx_ts:
+          format: date-time
+          type: string
         outcome:
           type:
           - string
@@ -1386,23 +1369,10 @@ components:
         price:
           format: double
           type: number
-        side:
-          type:
-          - string
-          - 'null'
         size:
           format: double
           type: number
-        source_channel:
-          type: string
         taker_address:
-          type:
-          - string
-          - 'null'
-        timestamp:
-          format: date-time
-          type: string
-        tx_hash:
           type:
           - string
           - 'null'
@@ -1412,10 +1382,11 @@ components:
           - number
           - 'null'
       required:
+      - exchange_ts
+      - id
+      - openpx_ts
       - price
       - size
-      - source_channel
-      - timestamp
       title: MarketTrade
       type: object
     MarketType:
@@ -2011,51 +1982,38 @@ components:
       title: SportResult
       type: object
     TradesRequest:
-      description: Request for fetching recent public trades ("tape") for a market outcome.
+      description: "Request for fetching recent public trades (\"tape\") for a market.\n\n`asset_id` is the market identifier\
+        \ \u2014 Kalshi market ticker or Polymarket Gamma slug. Both Yes and No outcomes' trades are returned interleaved;\
+        \ use `MarketTrade.outcome` to distinguish."
       properties:
+        asset_id:
+          type: string
         cursor:
-          description: Opaque pagination cursor from a previous response.
+          description: Opaque cursor from a prior response.
           type:
           - string
           - 'null'
         end_ts:
-          description: Unix seconds (inclusive)
+          description: Unix seconds (inclusive upper bound).
           format: int64
           type:
           - integer
           - 'null'
         limit:
-          description: Max number of trades to return (exchange-specific caps may apply).
+          description: Max trades to return. Capped per exchange (Kalshi 1000, Polymarket 500).
           format: uint
           minimum: 0.0
           type:
           - integer
           - 'null'
-        market_ref:
-          description: Optional alternate market identifier for trade endpoints (e.g., Polymarket conditionId). When provided,
-            exchanges should prefer this over `market_ticker`.
-          type:
-          - string
-          - 'null'
-        market_ticker:
-          description: Exchange-native market identifier.
-          type: string
-        outcome:
-          type:
-          - string
-          - 'null'
         start_ts:
-          description: Unix seconds (inclusive)
+          description: Unix seconds (inclusive lower bound).
           format: int64
           type:
           - integer
           - 'null'
-        token_id:
-          type:
-          - string
-          - 'null'
       required:
-      - market_ticker
+      - asset_id
       title: TradesRequest
       type: object
     WsUpdate:

--- a/docs/schemas/mappings/trade.mdx
+++ b/docs/schemas/mappings/trade.mdx
@@ -1,0 +1,39 @@
+---
+title: "MarketTrade mapping"
+description: "How each upstream exchange schema maps to OpenPX MarketTrade."
+---
+
+_Normalized public market trade, suitable for "tape" UIs._
+
+## Coverage
+
+| Exchange | Sourced | Synthetic | Omitted |
+|---|---|---|---|
+| kalshi | 7 | 2 | 1 |
+| polymarket | 6 | 4 | 0 |
+
+**Sourced** — value copied or transformed from a documented upstream field.  
+**Synthetic** — computed by OpenPX, not present upstream.  
+**Omitted** — upstream does not expose this concept.  
+
+## Field crosswalk
+
+| Unified field | Type | kalshi source | polymarket source | Transform | Notes |
+|---|---|---|---|---|---|
+| `id` | string | `Trade.trade_id` (string) | `Trade.transactionHash` (string) | direct | **kalshi:** Kalshi-issued unique trade id, stable across replays. Required on the unified surface; rows missing this field are dropped at parse time rather than synthesized. **polymarket:** On-chain transaction hash. Doubles as the unified `id` because Polymarket's public tape has no separate trade id — every executed trade lands in exactly one Polygon tx. Rows without a tx hash are dropped (the Data API only emits null `transactionHash` for unsettled trades, which we exclude from the tape view). |
+| `price` | number (double) | `Trade.yes_price_dollars` (FixedPointDollars), fallback `Trade.no_price_dollars` | `Trade.price` (number) | fixed_point_dollars / direct | **kalshi:** Yes-anchored: unified `price` is always the Yes-side execution price. Kalshi emits both yes_price_dollars and no_price_dollars on every row (Oct 9, 2025 changelog). Cents-form legacy values (e.g. `99.0`) are normalized by dividing by 100. Rows that fail to parse a Yes price are dropped. **polymarket:** Polymarket already returns price as a decimal probability in [0,1]; copied as-is. On binary markets the unified row's `price` is the executed price of the specific outcome token (use `outcome` to know whether it's Yes-side or No-side). |
+| `size` | number (double) | `Trade.count_fp` (FixedPointCount) | `Trade.size` (number) | fixed_point_count / direct | **kalshi:** Number of contracts at fixed-point precision (e.g. `"10.00"` → `10.0`). The legacy integer `count` field is no longer mapped — `count_fp` is required on every trade per the spec. **polymarket:** Already a `number` in the spec. Copied as-is. |
+| `aggressor_side` | string? | `Trade.taker_side` (string) | _computed_ — `{Trade.side, Trade.outcome} → buy\|sell, Yes-anchored` | kalshi_taker_to_buy_sell / synthetic | **kalshi:** Yes-anchored: `taker_side=yes` (taker bought Yes) → `"buy"`; `taker_side=no` (taker bought No, equivalent to selling Yes) → `"sell"`. Encodes whether the trade pushed Yes price up or down. **polymarket:** Polymarket's top-level `side` is the proxyWallet's BUY/SELL on the specific outcome token. With `takerOnly=true` (the unified tape default) the proxyWallet is the taker. We anchor to the Yes side: `BUY` of Yes or `SELL` of No → `"buy"`; `SELL` of Yes or `BUY` of No → `"sell"`. Non-binary markets fall through to the raw side string. |
+| `outcome` | string? | _computed_ — `Trade.taker_side ∈ {yes, no} → {"Yes", "No"}` | `Trade.outcome` (string) | synthetic / direct | **kalshi:** Kalshi binary markets only address Yes/No; the row's `outcome` mirrors which side the taker took. Synthetic rather than sourced because no top-level `outcome` field exists on the upstream Trade — we re-canonicalize the enum. **polymarket:** Free-form outcome label as published by Polymarket (typically `"Yes"`/`"No"` on binary markets, but categorical markets emit the outcome string as-is, e.g. `"Trump"`). |
+| `yes_price` | number? (double) | `Trade.yes_price_dollars` (FixedPointDollars) | _computed_ — Trade.price when Trade.outcome == "Yes"; else null | fixed_point_dollars / synthetic | **kalshi:** Same source as the canonical `price`; restated here so consumers can read the Yes reference without inspecting `outcome`. **polymarket:** Polymarket trades are per-outcome-token, so only one of `yes_price` / `no_price` can be filled per row. Set when the row's outcome is `"Yes"`; otherwise None. Do NOT derive from `1 - no_price` — the spreads are not mirror-image-tight. |
+| `no_price` | number? (double) | `Trade.no_price_dollars` (FixedPointDollars) | _computed_ — Trade.price when Trade.outcome == "No"; else null | fixed_point_dollars / synthetic | **kalshi:** Direct No-side reference; available on every Kalshi trade alongside `yes_price_dollars`. Do NOT derive as `1 - yes_price` — the mirror identity holds at top-of-book but not on every executed trade (Kalshi's matching engine can fill both sides at non-mirrored prices on subpenny ticks). **polymarket:** Symmetric counterpart of `yes_price` for the No-side outcome token. None when the row is a Yes-token trade. |
+| `taker_address` | string? | _not exposed_ | `Trade.proxyWallet` (Address) | direct | **kalshi:** Kalshi public trades expose no wallet/account identifiers — the tape is fully anonymous beyond `taker_side`. Always None. **polymarket:** On-chain proxy wallet address of the taker. We hardcode `takerOnly=true` on the underlying Data API call, so this is unambiguously the taker. Polymarket's public tape exposes no maker-side identifier (Jun 3, 2025 changelog mentioned a MakerOrder.side nested object that does not appear in the current spec). |
+| `exchange_ts` | string (date-time) | `Trade.created_time` (string (date-time)) | `Trade.timestamp` (integer (int64)) | parse_datetime / unix_seconds_to_utc | **kalshi:** RFC3339 string from the upstream; parsed to UTC. **polymarket:** Polymarket emits trade timestamps as `int64` unix seconds (NOT milliseconds — the orderbook surface uses ms strings, but the tape uses second-precision integers). Parsed via `chrono::DateTime::\<Utc\>::from_timestamp`. |
+| `openpx_ts` | string (date-time) | _computed_ — wall-clock UTC stamped at response-serialization time | _computed_ — wall-clock UTC stamped at response-serialization time | synthetic | Stamped once per `fetch_trades` call (not per row) so a single page shares one `openpx_ts`. Lets consumers compute end-to-end latency against `exchange_ts` and de-duplicate retries that produce identical payloads. |
+
+## Source specs
+
+- **kalshi** &middot; [`schema/upstream/kalshi.openapi.yaml`](https://github.com/openpx-trade/openpx/blob/main/schema/upstream/kalshi.openapi.yaml)
+- **polymarket** &middot; [`schema/upstream/polymarket-data.openapi.yaml`](https://github.com/openpx-trade/openpx/blob/main/schema/upstream/polymarket-data.openapi.yaml)
+
+> Tables are auto-generated from `schema/mappings/`. CI fails on unresolved $refs and on type mismatches for `transform: direct`. Drift in upstream specs surfaces here on the daily refresh PR.

--- a/engine/cli/src/main.rs
+++ b/engine/cli/src/main.rs
@@ -80,13 +80,13 @@ enum Command {
     FetchMarketLineage { market_ticker: String },
     /// Fetch full-depth L2 orderbook (bids + asks) for an asset_id (Kalshi market ticker or Polymarket token id)
     FetchOrderbook { asset_id: String },
-    /// Fetch recent trades
+    /// Fetch recent trades — `asset_id` is the Kalshi ticker or Polymarket slug
     FetchTrades {
-        market_ticker: String,
+        asset_id: String,
         #[arg(long)]
-        outcome: Option<String>,
+        start_ts: Option<i64>,
         #[arg(long)]
-        token_id: Option<String>,
+        end_ts: Option<i64>,
         #[arg(long)]
         limit: Option<usize>,
         #[arg(long)]
@@ -276,19 +276,16 @@ async fn run_rest_command(exchange: &ExchangeInner, cmd: Command) {
                 print_json(&ob);
             }
             Command::FetchTrades {
-                market_ticker,
-                outcome,
-                token_id,
+                asset_id,
+                start_ts,
+                end_ts,
                 limit,
                 cursor,
             } => {
                 let req = TradesRequest {
-                    market_ticker,
-                    market_ref: None,
-                    outcome,
-                    token_id,
-                    start_ts: None,
-                    end_ts: None,
+                    asset_id,
+                    start_ts,
+                    end_ts,
                     limit,
                     cursor,
                 };

--- a/engine/core/src/exchange/traits.rs
+++ b/engine/core/src/exchange/traits.rs
@@ -78,7 +78,9 @@ pub trait Exchange: Send + Sync {
         ))
     }
 
-    /// Fetch a paginated tape of recent public trades for a market outcome.
+    /// Fetch a paginated tape of recent public trades for a market.
+    /// Both Yes and No outcomes' trades are returned interleaved; consumers
+    /// distinguish via `MarketTrade.outcome`.
     async fn fetch_trades(
         &self,
         req: TradesRequest,
@@ -237,24 +239,22 @@ pub struct ExchangeInfo {
     pub has_create_orders_batch: bool,
 }
 
-/// Request for fetching recent public trades ("tape") for a market outcome.
+/// Request for fetching recent public trades ("tape") for a market.
+///
+/// `asset_id` is the market identifier — Kalshi market ticker or Polymarket
+/// Gamma slug. Both Yes and No outcomes' trades are returned interleaved;
+/// use `MarketTrade.outcome` to distinguish.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct TradesRequest {
-    /// Exchange-native market identifier.
-    pub market_ticker: String,
-    /// Optional alternate market identifier for trade endpoints (e.g., Polymarket conditionId).
-    /// When provided, exchanges should prefer this over `market_ticker`.
-    pub market_ref: Option<String>,
-    pub outcome: Option<String>,
-    pub token_id: Option<String>,
-    /// Unix seconds (inclusive)
+    pub asset_id: String,
+    /// Unix seconds (inclusive lower bound).
     pub start_ts: Option<i64>,
-    /// Unix seconds (inclusive)
+    /// Unix seconds (inclusive upper bound).
     pub end_ts: Option<i64>,
-    /// Max number of trades to return (exchange-specific caps may apply).
+    /// Max trades to return. Capped per exchange (Kalshi 1000, Polymarket 500).
     pub limit: Option<usize>,
-    /// Opaque pagination cursor from a previous response.
+    /// Opaque cursor from a prior response.
     pub cursor: Option<String>,
 }
 

--- a/engine/core/src/models/trade.rs
+++ b/engine/core/src/models/trade.rs
@@ -38,23 +38,22 @@ pub struct PublicTrade {
 
 /// Normalized public market trade, suitable for "tape" UIs.
 ///
-/// - `price` is normalized to [0.0, 1.0] across all exchanges.
-/// - `timestamp` is the exchange-provided trade timestamp (UTC).
+/// - `price` is normalized to [0.0, 1.0]; anchored to the Yes side on
+///   binary markets — use `no_price` for the No-side reference.
+/// - `aggressor_side` is "buy" / "sell" relative to the Yes side on binary
+///   markets — "buy" means upward pressure on Yes, "sell" downward.
+/// - `exchange_ts` is the upstream-provided trade timestamp.
+/// - `openpx_ts` is wall-clock when OpenPX served the response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct MarketTrade {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<String>,
+    pub id: String,
     pub price: f64,
     pub size: f64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub side: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub aggressor_side: Option<String>,
-    pub timestamp: DateTime<Utc>,
-    pub source_channel: std::borrow::Cow<'static, str>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tx_hash: Option<String>,
+    pub exchange_ts: DateTime<Utc>,
+    pub openpx_ts: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub outcome: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/engine/exchanges/kalshi/src/exchange.rs
+++ b/engine/exchanges/kalshi/src/exchange.rs
@@ -1,5 +1,4 @@
-use metrics::{counter, histogram};
-use std::borrow::Cow;
+use metrics::histogram;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -1354,7 +1353,6 @@ impl Exchange for Kalshi {
         struct Trade {
             trade_id: Option<String>,
             created_time: chrono::DateTime<chrono::Utc>,
-            /// Kalshi returns this as the YES price (0.0-1.0), even when taker_side=no.
             price: Option<f64>,
             yes_price_dollars: Option<String>,
             no_price: Option<f64>,
@@ -1364,35 +1362,28 @@ impl Exchange for Kalshi {
             taker_side: Option<String>,
         }
 
-        let wants_no = req
-            .outcome
-            .as_deref()
-            .is_some_and(|o| o.eq_ignore_ascii_case("no"));
-
-        let ticker = req
-            .token_id
-            .as_deref()
-            .or(req.market_ref.as_deref())
-            .unwrap_or(&req.market_ticker);
         let limit = req.limit.unwrap_or(200).clamp(1, 1000);
-        let mut path = format!("/markets/trades?ticker={}&limit={}", ticker, limit);
+        let mut path = format!("/markets/trades?ticker={}&limit={}", req.asset_id, limit);
         if let Some(start_ts) = req.start_ts {
-            path.push_str(&format!("&min_ts={}", start_ts));
+            path.push_str(&format!("&min_ts={start_ts}"));
         }
         if let Some(end_ts) = req.end_ts {
-            path.push_str(&format!("&max_ts={}", end_ts));
+            path.push_str(&format!("&max_ts={end_ts}"));
         }
         if let Some(cursor) = &req.cursor {
-            path.push_str(&format!("&cursor={}", cursor));
+            path.push_str(&format!("&cursor={cursor}"));
         }
 
         let resp: TradesResponse = self.get(&path).await.map_err(to_openpx)?;
         let next_cursor = resp.cursor.filter(|c| !c.is_empty());
+        let openpx_ts = chrono::Utc::now();
 
         let trades = resp
             .trades
             .into_iter()
             .filter_map(|t| {
+                let id = t.trade_id?;
+
                 let price_yes = if let Some(price) = t.price {
                     normalize_kalshi_trade_price(price)
                 } else {
@@ -1402,7 +1393,6 @@ impl Exchange for Kalshi {
                         .and_then(normalize_kalshi_trade_price)
                 }?;
 
-                // Parse no_price from exchange data; do NOT derive as 1-yes_price.
                 let price_no = if let Some(np) = t.no_price {
                     normalize_kalshi_trade_price(np)
                 } else {
@@ -1412,63 +1402,33 @@ impl Exchange for Kalshi {
                         .and_then(normalize_kalshi_trade_price)
                 };
 
-                let size =
-                    if let Some(size) = t.count_fp.as_deref().and_then(|s| s.parse::<f64>().ok()) {
-                        size
-                    } else {
-                        t.count?
-                    };
-
+                let size = t
+                    .count_fp
+                    .as_deref()
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .or(t.count)?;
                 if size <= 0.0 {
                     return None;
                 }
 
-                let price = if wants_no {
-                    match price_no {
-                        Some(p) if p > 0.0 && p < 1.0 => p,
-                        _ => {
-                            counter!(
-                                "openpx.kalshi.trade_no_price_null",
-                                "operation" => "fetch_trades"
-                            )
-                            .increment(1);
-                            return None; // skip trade when no_price unavailable
-                        }
+                let (aggressor_side, outcome) = match t.taker_side.as_deref() {
+                    Some(s) if s.eq_ignore_ascii_case("yes") => {
+                        (Some("buy".to_string()), Some("Yes".to_string()))
                     }
-                } else {
-                    price_yes
+                    Some(s) if s.eq_ignore_ascii_case("no") => {
+                        (Some("sell".to_string()), Some("No".to_string()))
+                    }
+                    _ => (None, None),
                 };
-                if price <= 0.0 || price >= 1.0 {
-                    // Defensive: avoid emitting invalid normalized prices.
-                    return None;
-                }
-
-                let aggressor_side = t
-                    .taker_side
-                    .as_deref()
-                    .and_then(|s| match s.to_ascii_lowercase().as_str() {
-                        "yes" => Some(if wants_no { "sell" } else { "buy" }),
-                        "no" => Some(if wants_no { "buy" } else { "sell" }),
-                        _ => None,
-                    })
-                    .map(str::to_string);
 
                 Some(MarketTrade {
-                    id: t.trade_id,
-                    price,
+                    id,
+                    price: price_yes,
                     size,
-                    side: None,
                     aggressor_side,
-                    timestamp: t.created_time,
-                    source_channel: Cow::Borrowed("kalshi_rest_trade"),
-                    tx_hash: None,
-                    outcome: t.taker_side.as_deref().and_then(|s| {
-                        match s.to_ascii_lowercase().as_str() {
-                            "yes" => Some("Yes".to_string()),
-                            "no" => Some("No".to_string()),
-                            _ => None,
-                        }
-                    }),
+                    exchange_ts: t.created_time,
+                    openpx_ts,
+                    outcome,
                     yes_price: Some(price_yes),
                     no_price: price_no,
                     taker_address: None,

--- a/engine/exchanges/kalshi/tests/exchange_tests.rs
+++ b/engine/exchanges/kalshi/tests/exchange_tests.rs
@@ -237,7 +237,7 @@ fn sample_trades_response_with_no_price() -> serde_json::Value {
 }
 
 #[tokio::test]
-async fn fetch_trades_no_outcome_uses_real_no_price() {
+async fn fetch_trades_yes_anchored_emits_both_sides() {
     let mock_server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/markets/trades"))
@@ -252,125 +252,40 @@ async fn fetch_trades_no_outcome_uses_real_no_price() {
         .with_verbose(false);
     let exchange = Kalshi::new(config).unwrap();
 
-    // Query with outcome=No
     let req = TradesRequest {
-        market_ticker: "TEST-TICKER".into(),
-        market_ref: None,
-        outcome: Some("No".into()),
-        token_id: None,
-        start_ts: None,
-        end_ts: None,
+        asset_id: "TEST-TICKER".into(),
         limit: Some(100),
-        cursor: None,
+        ..Default::default()
     };
 
     let (trades, _cursor) = exchange.fetch_trades(req).await.unwrap();
 
-    // t2 has null no_price → should be SKIPPED
-    // t1/t3/t4 have valid no_price (t4 is cents-like 99.0) → should be included
-    assert_eq!(
-        trades.len(),
-        3,
-        "trade with null no_price should be excluded"
-    );
+    // All 4 trades come back: price is always yes_price; no_price may be None.
+    assert_eq!(trades.len(), 4);
 
-    // t1: no_price=0.42 (NOT 1.0 - 0.60 = 0.40)
-    let t1 = trades
-        .iter()
-        .find(|t| t.id.as_deref() == Some("t1"))
-        .unwrap();
-    assert!(
-        (t1.price - 0.42).abs() < 1e-8,
-        "price should be real no_price (0.42), not 1-yes_price (0.40); got {}",
-        t1.price
-    );
-    // aggressor_side should be flipped: taker_side=yes → "sell" for No perspective
-    assert_eq!(t1.aggressor_side.as_deref(), Some("sell"));
-    // yes_price and no_price are reference fields, NOT swapped
+    // t1: yes-side taker → buy + Yes outcome; both prices populated.
+    let t1 = trades.iter().find(|t| t.id == "t1").unwrap();
+    assert!((t1.price - 0.60).abs() < 1e-8);
+    assert_eq!(t1.aggressor_side.as_deref(), Some("buy"));
+    assert_eq!(t1.outcome.as_deref(), Some("Yes"));
     assert_eq!(t1.yes_price, Some(0.60));
     assert_eq!(t1.no_price, Some(0.42));
 
-    // t3: no_price=0.31 (NOT 1.0 - 0.70 = 0.30)
-    let t3 = trades
-        .iter()
-        .find(|t| t.id.as_deref() == Some("t3"))
-        .unwrap();
-    assert!(
-        (t3.price - 0.31).abs() < 1e-8,
-        "price should be real no_price (0.31), not 1-yes_price (0.30); got {}",
-        t3.price
-    );
+    // t2: no_price is null → no_price=None, but trade still emitted with yes_price.
+    let t2 = trades.iter().find(|t| t.id == "t2").unwrap();
+    assert!((t2.price - 0.55).abs() < 1e-8);
+    assert_eq!(t2.aggressor_side.as_deref(), Some("sell"));
+    assert_eq!(t2.outcome.as_deref(), Some("No"));
+    assert_eq!(t2.yes_price, Some(0.55));
+    assert_eq!(t2.no_price, None);
 
-    // t4: no_price=99.0 (cents-like) should normalize to 0.99
-    let t4 = trades
-        .iter()
-        .find(|t| t.id.as_deref() == Some("t4"))
-        .unwrap();
-    assert!(
-        (t4.price - 0.99).abs() < 1e-8,
-        "price should normalize no_price cents (99.0 -> 0.99); got {}",
-        t4.price
-    );
-    assert_eq!(t4.yes_price, Some(0.01));
-    assert_eq!(t4.no_price, Some(0.99));
-    assert_eq!(t4.outcome.as_deref(), Some("No"));
-}
-
-#[tokio::test]
-async fn fetch_trades_yes_outcome_uses_yes_price() {
-    let mock_server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/markets/trades"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(sample_trades_response_with_no_price()),
-        )
-        .mount(&mock_server)
-        .await;
-
-    let config = KalshiConfig::new()
-        .with_api_url(mock_server.uri())
-        .with_verbose(false);
-    let exchange = Kalshi::new(config).unwrap();
-
-    // Query with outcome=Yes (default)
-    let req = TradesRequest {
-        market_ticker: "TEST-TICKER".into(),
-        market_ref: None,
-        outcome: Some("Yes".into()),
-        token_id: None,
-        start_ts: None,
-        end_ts: None,
-        limit: Some(100),
-        cursor: None,
-    };
-
-    let (trades, _cursor) = exchange.fetch_trades(req).await.unwrap();
-
-    // All 4 trades should be included for Yes perspective (no null filtering)
-    assert_eq!(
-        trades.len(),
-        4,
-        "all trades should be included for Yes perspective"
-    );
-
-    // t1: price should be yes_price=0.60
-    let t1 = trades
-        .iter()
-        .find(|t| t.id.as_deref() == Some("t1"))
-        .unwrap();
-    assert!((t1.price - 0.60).abs() < 1e-8);
-    // aggressor_side: taker_side=yes → "buy" for Yes perspective
-    assert_eq!(t1.aggressor_side.as_deref(), Some("buy"));
-    assert_eq!(t1.outcome.as_deref(), Some("Yes"));
-
-    // t4 yes_price=1.0 (cents-like) should normalize to 0.01 in yes perspective too
-    let t4 = trades
-        .iter()
-        .find(|t| t.id.as_deref() == Some("t4"))
-        .unwrap();
+    // t4: cents-like normalization (1.0 → 0.01, 99.0 → 0.99).
+    let t4 = trades.iter().find(|t| t.id == "t4").unwrap();
     assert!((t4.price - 0.01).abs() < 1e-8);
     assert_eq!(t4.yes_price, Some(0.01));
     assert_eq!(t4.no_price, Some(0.99));
+    assert_eq!(t4.aggressor_side.as_deref(), Some("sell"));
+    assert_eq!(t4.outcome.as_deref(), Some("No"));
 }
 
 // ---------------------------------------------------------------------------
@@ -995,7 +910,7 @@ async fn test_fetch_trades_empty_response() {
 
     // #when
     let req = TradesRequest {
-        market_ticker: "EMPTY-MKT".into(),
+        asset_id: "EMPTY-MKT".into(),
         ..Default::default()
     };
     let (trades, cursor) = exchange.fetch_trades(req).await.unwrap();
@@ -1036,7 +951,7 @@ async fn test_fetch_trades_returns_cursor() {
 
     // #when
     let req = TradesRequest {
-        market_ticker: "TEST-MKT".into(),
+        asset_id: "TEST-MKT".into(),
         ..Default::default()
     };
     let (trades, cursor) = exchange.fetch_trades(req).await.unwrap();
@@ -1087,15 +1002,14 @@ async fn test_fetch_trades_filters_zero_size() {
 
     // #when
     let req = TradesRequest {
-        market_ticker: "TEST-MKT".into(),
-        outcome: Some("Yes".into()),
+        asset_id: "TEST-MKT".into(),
         ..Default::default()
     };
     let (trades, _) = exchange.fetch_trades(req).await.unwrap();
 
     // #then - zero-size trade should be filtered out
     assert_eq!(trades.len(), 1);
-    assert_eq!(trades[0].id.as_deref(), Some("t-valid"));
+    assert_eq!(trades[0].id, "t-valid");
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -9,7 +9,6 @@ use polymarket_client_sdk_v2::clob::{Client as SdkClient, Config as SdkConfig};
 use polymarket_client_sdk_v2::contract_config;
 use polymarket_client_sdk_v2::types::{Decimal, U256};
 use polymarket_client_sdk_v2::POLYGON;
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -721,7 +720,9 @@ impl Polymarket {
         self.rate_limit().await;
 
         let data_api_url = &self.config.data_api_url;
+        // Data API runtime caps (changelog 2025-08-26): limit ≤ 500, offset ≤ 1000.
         const PAGE_SIZE: usize = 500;
+        const OFFSET_CAP: usize = 1000;
 
         let total_limit = limit.unwrap_or(100);
         let initial_offset = offset.unwrap_or(0);
@@ -731,7 +732,13 @@ impl Polymarket {
         let mut current_offset = initial_offset;
 
         loop {
-            let page_limit = PAGE_SIZE.min(total_limit - all_trades.len());
+            if current_offset >= OFFSET_CAP {
+                break;
+            }
+            let remaining_offset = OFFSET_CAP - current_offset;
+            let page_limit = PAGE_SIZE
+                .min(total_limit - all_trades.len())
+                .min(remaining_offset);
             if page_limit == 0 {
                 break;
             }
@@ -1486,9 +1493,8 @@ impl Exchange for Polymarket {
         &self,
         req: TradesRequest,
     ) -> Result<(Vec<MarketTrade>, Option<String>), OpenPxError> {
-        let token_id = req.token_id.clone().ok_or_else(|| {
-            OpenPxError::InvalidInput("token_id required for polymarket trades".into())
-        })?;
+        // Data API caps `limit` at 500 and `offset` at 1000 (changelog 2025-08-26).
+        const POLY_OFFSET_CAP: usize = 1000;
 
         let desired = req.limit.unwrap_or(200).clamp(1, 500);
         let offset: usize = req
@@ -1496,22 +1502,24 @@ impl Exchange for Polymarket {
             .as_deref()
             .and_then(|c| c.parse().ok())
             .unwrap_or(0);
-        // Trades are returned for the whole condition; over-fetch and filter by outcome token.
-        let overfetch = (desired.saturating_mul(5)).clamp(desired, 2000);
+        if offset >= POLY_OFFSET_CAP {
+            return Ok((Vec::new(), None));
+        }
+        // Cap fetch within the remaining offset budget so we never exceed the cap.
+        let fetchable = desired.min(POLY_OFFSET_CAP - offset);
 
-        // Need Polymarket conditionId (data-api "market" param), not the Gamma market id.
-        let condition_id =
-            if let Some(condition_id) = req.market_ref.clone().filter(|s| !s.trim().is_empty()) {
-                condition_id
-            } else {
-                let market = self.fetch_market(&req.market_ticker).await?;
-                market.condition_id.clone().unwrap_or_default()
-            };
+        // Slug → conditionId via Gamma. Cached upstream by `fetch_market`.
+        let market = self.fetch_market(&req.asset_id).await?;
+        let condition_id = market.condition_id.clone().ok_or_else(|| {
+            OpenPxError::Exchange(px_core::ExchangeError::Api(
+                "market missing condition_id".into(),
+            ))
+        })?;
 
         let raw = self
             .fetch_public_trades(
                 Some(&condition_id),
-                Some(overfetch),
+                Some(fetchable),
                 Some(offset),
                 None,
                 None,
@@ -1528,51 +1536,48 @@ impl Exchange for Polymarket {
             .and_then(|s| chrono::DateTime::<chrono::Utc>::from_timestamp(s, 0));
 
         let raw_count = raw.len();
+        let openpx_ts = chrono::Utc::now();
 
-        let mut trades: Vec<MarketTrade> = raw
+        let trades: Vec<MarketTrade> = raw
             .into_iter()
-            .filter(|t| t.asset == token_id)
             .filter(|t| {
-                if let Some(start) = start_ts {
-                    if t.timestamp < start {
-                        return false;
-                    }
-                }
-                if let Some(end) = end_ts {
-                    if t.timestamp > end {
-                        return false;
-                    }
-                }
-                true
+                start_ts.is_none_or(|s| t.timestamp >= s) && end_ts.is_none_or(|e| t.timestamp <= e)
             })
-            .map(|t| {
-                let side_str = t.side.trim().to_string();
+            .filter_map(|t| {
+                let id = t.transaction_hash.clone()?;
                 let outcome_str = t.outcome.as_deref().unwrap_or("").trim();
                 let is_yes = outcome_str.eq_ignore_ascii_case("Yes");
                 let is_no = outcome_str.eq_ignore_ascii_case("No");
-                MarketTrade {
-                    id: t.transaction_hash.clone(),
+
+                // Yes-anchored aggressor on binary markets: a "buy" of No is a
+                // "sell" relative to Yes-side pressure, and vice versa.
+                let side_lower = t.side.trim().to_ascii_lowercase();
+                let aggressor_side = match (side_lower.as_str(), is_yes, is_no) {
+                    ("buy", true, _) | ("sell", _, true) => Some("buy".to_string()),
+                    ("sell", true, _) | ("buy", _, true) => Some("sell".to_string()),
+                    (s, _, _) if !s.is_empty() => Some(s.to_string()),
+                    _ => None,
+                };
+
+                Some(MarketTrade {
+                    id,
                     price: t.price,
                     size: t.size,
-                    side: (!side_str.is_empty()).then(|| side_str.clone()),
-                    aggressor_side: (!side_str.is_empty()).then_some(side_str),
-                    timestamp: t.timestamp,
-                    source_channel: Cow::Borrowed("polymarket_rest_trade"),
-                    tx_hash: t.transaction_hash.clone(),
+                    aggressor_side,
+                    exchange_ts: t.timestamp,
+                    openpx_ts,
                     outcome: t.outcome.clone(),
                     yes_price: if is_yes { Some(t.price) } else { None },
                     no_price: if is_no { Some(t.price) } else { None },
                     taker_address: Some(t.proxy_wallet.clone()),
-                }
+                })
             })
             .collect();
 
-        // data-api returns newest-first. Keep it that way for tape UIs.
-        trades.truncate(desired);
-
-        // Provide next_cursor if we got a full page of raw results (more data likely available).
-        let next_cursor = if raw_count >= overfetch {
-            Some((offset + overfetch).to_string())
+        // Emit a cursor only if more data is reachable within the offset cap.
+        let next_offset = offset + raw_count;
+        let next_cursor = if raw_count >= fetchable && next_offset < POLY_OFFSET_CAP {
+            Some(next_offset.to_string())
         } else {
             None
         };

--- a/engine/sdk/tests/live.rs
+++ b/engine/sdk/tests/live.rs
@@ -526,7 +526,7 @@ macro_rules! exchange_tests {
                 };
                 match ex
                     .fetch_trades(TradesRequest {
-                        market_ticker: markets[0].ticker.clone(),
+                        asset_id: markets[0].ticker.clone(),
                         limit: Some(10),
                         ..Default::default()
                     })
@@ -536,13 +536,8 @@ macro_rules! exchange_tests {
                         for t in &trades {
                             assert!(t.price >= 0.0 && t.price <= 1.0, "price should be 0..1");
                             assert!(t.size > 0.0, "size should be positive");
+                            assert!(!t.id.is_empty(), "id required");
                         }
-                    }
-                    Err(e) if format!("{e:?}").contains("token_id") => {
-                        eprintln!(
-                            "SKIP {}/fetch_trades: requires token_id",
-                            stringify!($exchange_id)
-                        );
                     }
                     Err(e) => panic!("fetch_trades failed: {e:?}"),
                 }
@@ -563,7 +558,7 @@ macro_rules! exchange_tests {
                 let limit = 5;
                 match ex
                     .fetch_trades(TradesRequest {
-                        market_ticker: markets[0].ticker.clone(),
+                        asset_id: markets[0].ticker.clone(),
                         limit: Some(limit),
                         ..Default::default()
                     })
@@ -595,7 +590,7 @@ macro_rules! exchange_tests {
                 // Fetch first page
                 let (page1, cursor) = match ex
                     .fetch_trades(TradesRequest {
-                        market_ticker: markets[0].ticker.clone(),
+                        asset_id: markets[0].ticker.clone(),
                         limit: Some(5),
                         ..Default::default()
                     })
@@ -613,7 +608,7 @@ macro_rules! exchange_tests {
                 if let Some(cursor) = cursor {
                     match ex
                         .fetch_trades(TradesRequest {
-                            market_ticker: markets[0].ticker.clone(),
+                            asset_id: markets[0].ticker.clone(),
                             limit: Some(5),
                             cursor: Some(cursor),
                             ..Default::default()
@@ -621,8 +616,7 @@ macro_rules! exchange_tests {
                         .await
                     {
                         Ok((page2, _)) => {
-                            // Pages should not overlap (if both non-empty)
-                            if !page2.is_empty() && page1[0].id.is_some() && page2[0].id.is_some() {
+                            if !page2.is_empty() {
                                 assert_ne!(
                                     page1[0].id, page2[0].id,
                                     "pagination returned same first trade"

--- a/justfile
+++ b/justfile
@@ -89,7 +89,7 @@ docs-serve:
     cd docs && mintlify dev
 
 check-sync: schema python-models node-models llms-txt check-mappings render-mappings openapi api-mdx asyncapi
-    git diff --exit-code schema/openpx.schema.json sdks/python/python/openpx/_models.py sdks/typescript/types/models.d.ts docs/llms.txt docs/api/ docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml
+    git diff --exit-code schema/openpx.schema.json sdks/python/python/openpx/_models.py sdks/typescript/types/models.d.ts docs/llms.txt docs/api/ docs/schemas/mappings/ docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml
 
 # ---------------------------------------------------------------------------
 # Versioning

--- a/schema/mappings/trade.yaml
+++ b/schema/mappings/trade.yaml
@@ -1,0 +1,213 @@
+# MarketTrade field mapping: how each upstream public-tape schema maps to
+# OpenPX MarketTrade.
+#
+# Coordinate-only: every $ref points at a resolvable path in
+# schema/upstream/<exchange>.openapi.yaml. Type info, nullability, and
+# descriptions are derived at validation/render time. Do not duplicate them
+# here.
+#
+# The hand-written normalizers — `fetch_trades` in
+# engine/exchanges/kalshi/src/exchange.rs and
+# engine/exchanges/polymarket/src/exchange.rs (the latter delegates to
+# `fetch_public_trades` and `parse_public_trade`) — are the implementation.
+# This file is the *contract* the implementation conforms to.
+unified_type: MarketTrade
+unified_schema: schema/openpx.schema.json#/definitions/MarketTrade
+
+# Kalshi: GET /markets/trades returns GetTradesResponse { trades: [Trade], cursor }.
+# Polymarket: GET /trades on the Data API returns a flat array of Trade objects.
+# Both surfaces are REST-only on the unified `fetch_trades`. WebSocket trade
+# events flow through a separate `ActivityTrade` type, not MarketTrade — see
+# engine/core/src/websocket/traits.rs.
+upstream_specs:
+  kalshi: schema/upstream/kalshi.openapi.yaml
+  polymarket: schema/upstream/polymarket-data.openapi.yaml
+
+# Transform vocabulary:
+#   direct                  — copy value as-is, types compatible
+#   fixed_point_dollars     — Kalshi $-string (FixedPointDollars) → decimal
+#                             probability [0,1]; cents-form values (>=1.0)
+#                             are divided by 100, then rounded to 6 decimals
+#                             and validated to be in (0,1)
+#   fixed_point_count       — Kalshi count-string (FixedPointCount) → f64
+#   parse_datetime          — RFC3339 string → DateTime<Utc>
+#   unix_seconds_to_utc     — Polymarket integer unix-seconds → DateTime<Utc>
+#   kalshi_taker_to_buy_sell — Kalshi taker_side enum (yes|no) → unified
+#                              aggressor_side ("buy" if yes, "sell" if no);
+#                              encodes Yes-anchored pressure
+#   poly_side_outcome_to_buy_sell — Polymarket {side: BUY|SELL, outcome: Yes|No}
+#                                   → unified aggressor_side, Yes-anchored:
+#                                   buys of Yes (or sells of No) → "buy";
+#                                   sells of Yes (or buys of No) → "sell".
+#                                   Non-binary outcomes pass side through.
+#   kalshi_taker_to_outcome — Kalshi taker_side (yes|no) → "Yes" / "No"
+fields:
+  # ---- Identity ----
+  - name: id
+    sources:
+      kalshi:
+        ref: "#/components/schemas/Trade/properties/trade_id"
+        transform: direct
+        notes: |
+          Kalshi-issued unique trade id, stable across replays. Required on
+          the unified surface; rows missing this field are dropped at parse
+          time rather than synthesized.
+      polymarket:
+        ref: "#/components/schemas/Trade/properties/transactionHash"
+        transform: direct
+        notes: |
+          On-chain transaction hash. Doubles as the unified `id` because
+          Polymarket's public tape has no separate trade id — every executed
+          trade lands in exactly one Polygon tx. Rows without a tx hash are
+          dropped (the Data API only emits null `transactionHash` for
+          unsettled trades, which we exclude from the tape view).
+
+  # ---- Price ----
+  - name: price
+    sources:
+      kalshi:
+        ref: "#/components/schemas/Trade/properties/yes_price_dollars"
+        fallback_ref: "#/components/schemas/Trade/properties/no_price_dollars"
+        transform: fixed_point_dollars
+        notes: |
+          Yes-anchored: unified `price` is always the Yes-side execution
+          price. Kalshi emits both yes_price_dollars and no_price_dollars on
+          every row (Oct 9, 2025 changelog). Cents-form legacy values
+          (e.g. `99.0`) are normalized by dividing by 100. Rows that fail to
+          parse a Yes price are dropped.
+      polymarket:
+        ref: "#/components/schemas/Trade/properties/price"
+        transform: direct
+        notes: |
+          Polymarket already returns price as a decimal probability in
+          [0,1]; copied as-is. On binary markets the unified row's `price`
+          is the executed price of the specific outcome token (use
+          `outcome` to know whether it's Yes-side or No-side).
+
+  - name: size
+    sources:
+      kalshi:
+        ref: "#/components/schemas/Trade/properties/count_fp"
+        transform: fixed_point_count
+        notes: |
+          Number of contracts at fixed-point precision (e.g. `"10.00"` →
+          `10.0`). The legacy integer `count` field is no longer mapped —
+          `count_fp` is required on every trade per the spec.
+      polymarket:
+        ref: "#/components/schemas/Trade/properties/size"
+        transform: direct
+        notes: Already a `number` in the spec. Copied as-is.
+
+  # ---- Direction ----
+  - name: aggressor_side
+    sources:
+      kalshi:
+        ref: "#/components/schemas/Trade/properties/taker_side"
+        transform: kalshi_taker_to_buy_sell
+        notes: |
+          Yes-anchored: `taker_side=yes` (taker bought Yes) → `"buy"`;
+          `taker_side=no` (taker bought No, equivalent to selling Yes) →
+          `"sell"`. Encodes whether the trade pushed Yes price up or down.
+      polymarket:
+        synthetic: "{Trade.side, Trade.outcome} → buy|sell, Yes-anchored"
+        notes: |
+          Polymarket's top-level `side` is the proxyWallet's BUY/SELL on
+          the specific outcome token. With `takerOnly=true` (the unified
+          tape default) the proxyWallet is the taker. We anchor to the
+          Yes side: `BUY` of Yes or `SELL` of No → `"buy"`; `SELL` of Yes
+          or `BUY` of No → `"sell"`. Non-binary markets fall through to
+          the raw side string.
+
+  - name: outcome
+    sources:
+      kalshi:
+        synthetic: "Trade.taker_side ∈ {yes, no} → {\"Yes\", \"No\"}"
+        notes: |
+          Kalshi binary markets only address Yes/No; the row's `outcome`
+          mirrors which side the taker took. Synthetic rather than sourced
+          because no top-level `outcome` field exists on the upstream
+          Trade — we re-canonicalize the enum.
+      polymarket:
+        ref: "#/components/schemas/Trade/properties/outcome"
+        transform: direct
+        notes: |
+          Free-form outcome label as published by Polymarket (typically
+          `"Yes"`/`"No"` on binary markets, but categorical markets emit
+          the outcome string as-is, e.g. `"Trump"`).
+
+  # ---- Two-sided price reference ----
+  - name: yes_price
+    sources:
+      kalshi:
+        ref: "#/components/schemas/Trade/properties/yes_price_dollars"
+        transform: fixed_point_dollars
+        notes: |
+          Same source as the canonical `price`; restated here so consumers
+          can read the Yes reference without inspecting `outcome`.
+      polymarket:
+        synthetic: "Trade.price when Trade.outcome == \"Yes\"; else null"
+        notes: |
+          Polymarket trades are per-outcome-token, so only one of
+          `yes_price` / `no_price` can be filled per row. Set when the
+          row's outcome is `"Yes"`; otherwise None. Do NOT derive from
+          `1 - no_price` — the spreads are not mirror-image-tight.
+
+  - name: no_price
+    sources:
+      kalshi:
+        ref: "#/components/schemas/Trade/properties/no_price_dollars"
+        transform: fixed_point_dollars
+        notes: |
+          Direct No-side reference; available on every Kalshi trade
+          alongside `yes_price_dollars`. Do NOT derive as `1 - yes_price`
+          — the mirror identity holds at top-of-book but not on every
+          executed trade (Kalshi's matching engine can fill both sides
+          at non-mirrored prices on subpenny ticks).
+      polymarket:
+        synthetic: "Trade.price when Trade.outcome == \"No\"; else null"
+        notes: |
+          Symmetric counterpart of `yes_price` for the No-side outcome
+          token. None when the row is a Yes-token trade.
+
+  # ---- Counterparty ----
+  - name: taker_address
+    sources:
+      kalshi:
+        omitted: true
+        notes: |
+          Kalshi public trades expose no wallet/account identifiers — the
+          tape is fully anonymous beyond `taker_side`. Always None.
+      polymarket:
+        ref: "#/components/schemas/Trade/properties/proxyWallet"
+        transform: direct
+        notes: |
+          On-chain proxy wallet address of the taker. We hardcode
+          `takerOnly=true` on the underlying Data API call, so this is
+          unambiguously the taker. Polymarket's public tape exposes no
+          maker-side identifier (Jun 3, 2025 changelog mentioned a
+          MakerOrder.side nested object that does not appear in the
+          current spec).
+
+  # ---- Timestamps ----
+  - name: exchange_ts
+    sources:
+      kalshi:
+        ref: "#/components/schemas/Trade/properties/created_time"
+        transform: parse_datetime
+        notes: RFC3339 string from the upstream; parsed to UTC.
+      polymarket:
+        ref: "#/components/schemas/Trade/properties/timestamp"
+        transform: unix_seconds_to_utc
+        notes: |
+          Polymarket emits trade timestamps as `int64` unix seconds (NOT
+          milliseconds — the orderbook surface uses ms strings, but the
+          tape uses second-precision integers). Parsed via
+          `chrono::DateTime::<Utc>::from_timestamp`.
+
+  - name: openpx_ts
+    synthetic: "wall-clock UTC stamped at response-serialization time"
+    notes: |
+      Stamped once per `fetch_trades` call (not per row) so a single page
+      shares one `openpx_ts`. Lets consumers compute end-to-end latency
+      against `exchange_ts` and de-duplicate retries that produce identical
+      payloads.

--- a/schema/openpx.schema.json
+++ b/schema/openpx.schema.json
@@ -847,7 +847,7 @@
       "type": "string"
     },
     "MarketTrade": {
-      "description": "Normalized public market trade, suitable for \"tape\" UIs.\n\n- `price` is normalized to [0.0, 1.0] across all exchanges. - `timestamp` is the exchange-provided trade timestamp (UTC).",
+      "description": "Normalized public market trade, suitable for \"tape\" UIs.\n\n- `price` is normalized to [0.0, 1.0]; anchored to the Yes side on binary markets — use `no_price` for the No-side reference. - `aggressor_side` is \"buy\" / \"sell\" relative to the Yes side on binary markets — \"buy\" means upward pressure on Yes, \"sell\" downward. - `exchange_ts` is the upstream-provided trade timestamp. - `openpx_ts` is wall-clock when OpenPX served the response.",
       "properties": {
         "aggressor_side": {
           "type": [
@@ -855,11 +855,12 @@
             "null"
           ]
         },
+        "exchange_ts": {
+          "format": "date-time",
+          "type": "string"
+        },
         "id": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": "string"
         },
         "no_price": {
           "format": "double",
@@ -867,6 +868,10 @@
             "number",
             "null"
           ]
+        },
+        "openpx_ts": {
+          "format": "date-time",
+          "type": "string"
         },
         "outcome": {
           "type": [
@@ -878,30 +883,11 @@
           "format": "double",
           "type": "number"
         },
-        "side": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "size": {
           "format": "double",
           "type": "number"
         },
-        "source_channel": {
-          "type": "string"
-        },
         "taker_address": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "timestamp": {
-          "format": "date-time",
-          "type": "string"
-        },
-        "tx_hash": {
           "type": [
             "string",
             "null"
@@ -916,10 +902,11 @@
         }
       },
       "required": [
+        "exchange_ts",
+        "id",
+        "openpx_ts",
         "price",
-        "size",
-        "source_channel",
-        "timestamp"
+        "size"
       ],
       "title": "MarketTrade",
       "type": "object"
@@ -1731,17 +1718,20 @@
       "type": "object"
     },
     "TradesRequest": {
-      "description": "Request for fetching recent public trades (\"tape\") for a market outcome.",
+      "description": "Request for fetching recent public trades (\"tape\") for a market.\n\n`asset_id` is the market identifier — Kalshi market ticker or Polymarket Gamma slug. Both Yes and No outcomes' trades are returned interleaved; use `MarketTrade.outcome` to distinguish.",
       "properties": {
+        "asset_id": {
+          "type": "string"
+        },
         "cursor": {
-          "description": "Opaque pagination cursor from a previous response.",
+          "description": "Opaque cursor from a prior response.",
           "type": [
             "string",
             "null"
           ]
         },
         "end_ts": {
-          "description": "Unix seconds (inclusive)",
+          "description": "Unix seconds (inclusive upper bound).",
           "format": "int64",
           "type": [
             "integer",
@@ -1749,7 +1739,7 @@
           ]
         },
         "limit": {
-          "description": "Max number of trades to return (exchange-specific caps may apply).",
+          "description": "Max trades to return. Capped per exchange (Kalshi 1000, Polymarket 500).",
           "format": "uint",
           "minimum": 0.0,
           "type": [
@@ -1757,40 +1747,17 @@
             "null"
           ]
         },
-        "market_ref": {
-          "description": "Optional alternate market identifier for trade endpoints (e.g., Polymarket conditionId). When provided, exchanges should prefer this over `market_ticker`.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "market_ticker": {
-          "description": "Exchange-native market identifier.",
-          "type": "string"
-        },
-        "outcome": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "start_ts": {
-          "description": "Unix seconds (inclusive)",
+          "description": "Unix seconds (inclusive lower bound).",
           "format": "int64",
           "type": [
             "integer",
             "null"
           ]
-        },
-        "token_id": {
-          "type": [
-            "string",
-            "null"
-          ]
         }
       },
       "required": [
-        "market_ticker"
+        "asset_id"
       ],
       "title": "TradesRequest",
       "type": "object"

--- a/sdks/python/python/openpx/_models.py
+++ b/sdks/python/python/openpx/_models.py
@@ -154,16 +154,14 @@ class MarketStatusFilter(Enum):
 
 class MarketTrade(BaseModel):
     aggressor_side: str | None = None
-    id: str | None = None
+    exchange_ts: AwareDatetime
+    id: str
     no_price: float | None = None
+    openpx_ts: AwareDatetime
     outcome: str | None = None
     price: float
-    side: str | None = None
     size: float
-    source_channel: str
     taker_address: str | None = None
-    timestamp: AwareDatetime
-    tx_hash: str | None = None
     yes_price: float | None = None
 
 
@@ -348,22 +346,18 @@ class SportResult(BaseModel):
 
 
 class TradesRequest(BaseModel):
-    cursor: str | None = Field(
-        None, description="Opaque pagination cursor from a previous response."
+    asset_id: str
+    cursor: str | None = Field(None, description="Opaque cursor from a prior response.")
+    end_ts: int | None = Field(
+        None, description="Unix seconds (inclusive upper bound)."
     )
-    end_ts: int | None = Field(None, description="Unix seconds (inclusive)")
     limit: conint(ge=0) | None = Field(
         None,
-        description="Max number of trades to return (exchange-specific caps may apply).",
+        description="Max trades to return. Capped per exchange (Kalshi 1000, Polymarket 500).",
     )
-    market_ref: str | None = Field(
-        None,
-        description="Optional alternate market identifier for trade endpoints (e.g., Polymarket conditionId). When provided, exchanges should prefer this over `market_ticker`.",
+    start_ts: int | None = Field(
+        None, description="Unix seconds (inclusive lower bound)."
     )
-    market_ticker: str = Field(..., description="Exchange-native market identifier.")
-    outcome: str | None = None
-    start_ts: int | None = Field(None, description="Unix seconds (inclusive)")
-    token_id: str | None = None
 
 
 class Kind5(Enum):

--- a/sdks/python/python/openpx/exchange.py
+++ b/sdks/python/python/openpx/exchange.py
@@ -169,19 +169,14 @@ class Exchange:
 
     def fetch_trades(
         self,
-        market_ticker: str,
+        asset_id: str,
         *,
-        market_ref: Optional[str] = None,
-        outcome: Optional[str] = None,
-        token_id: Optional[str] = None,
         start_ts: Optional[int] = None,
         end_ts: Optional[int] = None,
         limit: Optional[int] = None,
         cursor: Optional[str] = None,
     ) -> dict[str, Any]:
-        raw = self._native.fetch_trades(
-            market_ticker, market_ref, outcome, token_id, start_ts, end_ts, limit, cursor
-        )
+        raw = self._native.fetch_trades(asset_id, start_ts, end_ts, limit, cursor)
         try:
             from openpx._models import MarketTrade
             return {

--- a/sdks/python/src/exchange.rs
+++ b/sdks/python/src/exchange.rs
@@ -263,15 +263,11 @@ impl NativeExchange {
         pythonize(py, &fills).map_err(|e| to_py_err(e.to_string()))
     }
 
-    #[pyo3(signature = (market_ticker, market_ref=None, outcome=None, token_id=None, start_ts=None, end_ts=None, limit=None, cursor=None))]
-    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (asset_id, start_ts=None, end_ts=None, limit=None, cursor=None))]
     fn fetch_trades<'py>(
         &self,
         py: Python<'py>,
-        market_ticker: &str,
-        market_ref: Option<String>,
-        outcome: Option<String>,
-        token_id: Option<String>,
+        asset_id: &str,
         start_ts: Option<i64>,
         end_ts: Option<i64>,
         limit: Option<usize>,
@@ -279,10 +275,7 @@ impl NativeExchange {
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         let req = px_core::TradesRequest {
-            market_ticker: market_ticker.to_string(),
-            market_ref,
-            outcome,
-            token_id,
+            asset_id: asset_id.to_string(),
             start_ts,
             end_ts,
             limit,

--- a/sdks/typescript/src/exchange.rs
+++ b/sdks/typescript/src/exchange.rs
@@ -294,13 +294,9 @@ impl Exchange {
     }
 
     #[napi]
-    #[allow(clippy::too_many_arguments)]
     pub async fn fetch_trades(
         &self,
-        market_ticker: String,
-        market_ref: Option<String>,
-        outcome: Option<String>,
-        token_id: Option<String>,
+        asset_id: String,
         start_ts: Option<i64>,
         end_ts: Option<i64>,
         limit: Option<u32>,
@@ -308,10 +304,7 @@ impl Exchange {
     ) -> Result<serde_json::Value> {
         let inner = self.inner.clone();
         let req = px_core::TradesRequest {
-            market_ticker,
-            market_ref,
-            outcome,
-            token_id,
+            asset_id,
             start_ts,
             end_ts,
             limit: limit.map(|l| l as usize),

--- a/sdks/typescript/types/models.d.ts
+++ b/sdks/typescript/types/models.d.ts
@@ -570,23 +570,21 @@ export interface SettlementSource {
 /**
  * Normalized public market trade, suitable for "tape" UIs.
  *
- * - `price` is normalized to [0.0, 1.0] across all exchanges. - `timestamp` is the exchange-provided trade timestamp (UTC).
+ * - `price` is normalized to [0.0, 1.0]; anchored to the Yes side on binary markets — use `no_price` for the No-side reference. - `aggressor_side` is "buy" / "sell" relative to the Yes side on binary markets — "buy" means upward pressure on Yes, "sell" downward. - `exchange_ts` is the upstream-provided trade timestamp. - `openpx_ts` is wall-clock when OpenPX served the response.
  *
  * This interface was referenced by `OpenPX`'s JSON-Schema
  * via the `definition` "MarketTrade".
  */
 export interface MarketTrade {
   aggressor_side?: string | null;
-  id?: string | null;
+  exchange_ts: string;
+  id: string;
   no_price?: number | null;
+  openpx_ts: string;
   outcome?: string | null;
   price: number;
-  side?: string | null;
   size: number;
-  source_channel: string;
   taker_address?: string | null;
-  timestamp: string;
-  tx_hash?: string | null;
   yes_price?: number | null;
   [k: string]: unknown;
 }
@@ -770,37 +768,30 @@ export interface SportResult {
   [k: string]: unknown;
 }
 /**
- * Request for fetching recent public trades ("tape") for a market outcome.
+ * Request for fetching recent public trades ("tape") for a market.
+ *
+ * `asset_id` is the market identifier — Kalshi market ticker or Polymarket Gamma slug. Both Yes and No outcomes' trades are returned interleaved; use `MarketTrade.outcome` to distinguish.
  *
  * This interface was referenced by `OpenPX`'s JSON-Schema
  * via the `definition` "TradesRequest".
  */
 export interface TradesRequest {
+  asset_id: string;
   /**
-   * Opaque pagination cursor from a previous response.
+   * Opaque cursor from a prior response.
    */
   cursor?: string | null;
   /**
-   * Unix seconds (inclusive)
+   * Unix seconds (inclusive upper bound).
    */
   end_ts?: number | null;
   /**
-   * Max number of trades to return (exchange-specific caps may apply).
+   * Max trades to return. Capped per exchange (Kalshi 1000, Polymarket 500).
    */
   limit?: number | null;
   /**
-   * Optional alternate market identifier for trade endpoints (e.g., Polymarket conditionId). When provided, exchanges should prefer this over `market_ticker`.
-   */
-  market_ref?: string | null;
-  /**
-   * Exchange-native market identifier.
-   */
-  market_ticker: string;
-  outcome?: string | null;
-  /**
-   * Unix seconds (inclusive)
+   * Unix seconds (inclusive lower bound).
    */
   start_ts?: number | null;
-  token_id?: string | null;
   [k: string]: unknown;
 }


### PR DESCRIPTION
## Summary

Trims `fetch_trades` to a minimum-viable shape across both exchanges. The previous request struct carried four exchange-specific knobs (`market_ticker`, `market_ref`, `outcome`, `token_id`) that leaked Kalshi/Polymarket vocabulary into the unified surface. The previous response struct carried three dead fields (`side` duplicated `aggressor_side`; `source_channel` was REST-only and constant; `tx_hash` duplicated `id` on Polymarket).

Also fixes a silent Polymarket pagination bug: the data-api `/trades` runtime caps were reduced to `limit ≤ 500`, `offset ≤ 1000` on 2025-08-26, but `fetch_public_trades` paginated past the cap and returned empty pages without surfacing the boundary.

## Shape

Request — 8 fields → 5:
- `asset_id` — Kalshi market ticker or Polymarket Gamma slug
- `start_ts`, `end_ts`, `limit`, `cursor`

Response — 12 fields → 10:
- `id` (now required), `price`, `size`, `aggressor_side`, `exchange_ts`, `openpx_ts`, `outcome`, `yes_price`, `no_price`, `taker_address`
- Removed: `side`, `source_channel`, `tx_hash`. Renamed `timestamp` → `exchange_ts`. Added `openpx_ts`.

## Behavioral changes

- Both exchanges now return trades for **all outcomes interleaved**; consumers split via `MarketTrade.outcome`.
- Kalshi `price` is always anchored to the Yes side. The previous `outcome="No"` price-flip is gone — read `no_price` for the No-side reference.
- `aggressor_side` reflects buy/sell pressure on the Yes side on binary markets (Polymarket flips when the row's outcome is "No").
- Polymarket `fetch_public_trades` hard-caps `offset` at 1000 across all callers (`fetch_fills` benefits too) and emits no `next_cursor` once the cap is hit.

## Full-sync regen

`schema/openpx.schema.json`, `sdks/python/python/openpx/_models.py`, `sdks/typescript/types/models.d.ts`, `docs/openpx.openapi.yaml`, `docs/openpx.asyncapi.yaml`, `docs/api/trades/fetch-trades.mdx`, `docs/llms.txt`.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --lib --tests` — all 379 tests pass; 1 ignored (live ws test)
- [x] Kalshi mock-server tests rewritten for the new yes-anchored behavior
- [x] `just schema python-models node-models llms-txt openapi api-mdx asyncapi check-mappings render-mappings` — all clean
- [ ] Live verification against Kalshi + Polymarket (run `just live-test` with credentials before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)