### PR TITLE
ci(release): auto-sync derived docs on release-please PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -23,3 +24,38 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+  # Release-please bumps Cargo.toml workspace version but doesn't run our
+  # doc generators. tools/gen_openapi.py and tools/gen_asyncapi.py both read
+  # the version from [workspace.package], so docs/openpx.{open,async}api.yaml
+  # drift on every release PR — failing the SDK Sync Check until a human
+  # regenerates by hand. This job re-runs the generators on the release-please
+  # branch and pushes back if the version field (or anything else) drifted.
+  sync-release-pr-docs:
+    name: Sync derived docs on release PR
+    needs: release-please
+    if: needs.release-please.outputs.prs_created == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release-please--branches--main--components--openpx
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Regenerate openapi + asyncapi
+        run: |
+          python3 tools/gen_openapi.py
+          python3 tools/gen_asyncapi.py
+      - name: Commit and push if drifted
+        run: |
+          if git diff --quiet docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml; then
+            echo "no drift, skipping push"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/openpx.openapi.yaml docs/openpx.asyncapi.yaml
+          git commit -m "docs: sync openapi + asyncapi version after release bump"
+          git push


### PR DESCRIPTION
## What changed

Adds a `sync-release-pr-docs` job to `.github/workflows/release.yml` that runs after `release-please` whenever a release PR is opened or updated. The job checks out the release-please branch, re-runs the two derived-doc generators, and pushes back if anything drifted.

## Why

`release-please` bumps `[workspace.package].version` in `Cargo.toml` but doesn't run `tools/gen_openapi.py` / `tools/gen_asyncapi.py`. Both scripts read that field and write it into `docs/openpx.{open,async}api.yaml`, so every release PR ships with the wrong `version:` line in those two YAMLs and the **SDK Sync Check** CI gate goes red. Caught on v0.3.0 (PR #36) — fixed manually that round, but this happens on every release until automated.

## Files

- `.github/workflows/release.yml` — adds `sync-release-pr-docs` job (gated on `prs_created == 'true'`, idempotent — no commit when no drift)

## Tests

- Validated YAML locally with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
- Behavior will be observable on the next release-please cycle: a new commit by `github-actions[bot]` titled `docs: sync openapi + asyncapi version after release bump` should appear on the release branch immediately after release-please updates the PR

## Review focus

- Does `${{ secrets.RELEASE_PLEASE_TOKEN }}` have permission to push to the release-please branch? (It already pushes the version bumps via the release-please action, so should be fine — worth a sanity check)
- Branch name `release-please--branches--main--components--openpx` is hardcoded — matches current `release-please-config.json`. If the manifest config ever changes, this needs updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)