### PR TITLE
fix(polymarket): respect config.clob_url in get_orderbook + fetch_token_ids + SDK init

### DIFF
--- a/engine/exchanges/polymarket/src/exchange.rs
+++ b/engine/exchanges/polymarket/src/exchange.rs
@@ -26,7 +26,7 @@ use px_core::{
 
 use crate::approvals::{AllowanceStatus, ApprovalRequest, ApprovalResponse, TokenApprover};
 use crate::client::HttpClient;
-use crate::clob::{ApiCredentials, CLOB_URL};
+use crate::clob::ApiCredentials;
 use crate::config::PolymarketConfig;
 use crate::error::PolymarketError;
 
@@ -322,7 +322,7 @@ impl Polymarket {
             .as_ref()
             .ok_or_else(|| PolymarketError::Auth("private key required for trading".into()))?;
 
-        let unauth_client = SdkClient::new(CLOB_URL, SdkConfig::builder().build())
+        let unauth_client = SdkClient::new(&self.config.clob_url, SdkConfig::builder().build())
             .map_err(PolymarketError::from)?;
 
         // Use pre-set API credentials if available, otherwise derive from Polymarket
@@ -424,7 +424,7 @@ impl Polymarket {
             chain_id: Some(POLYGON),
         };
 
-        let unauth_client = SdkClient::new(CLOB_URL, SdkConfig::builder().build())
+        let unauth_client = SdkClient::new(&self.config.clob_url, SdkConfig::builder().build())
             .map_err(PolymarketError::from)?;
 
         let mut builder = unauth_client
@@ -588,7 +588,7 @@ impl Polymarket {
     pub async fn get_orderbook(&self, token_id: &str) -> Result<Orderbook, PolymarketError> {
         self.rate_limit().await;
 
-        let url = format!("{}/book?token_id={}", CLOB_URL, token_id);
+        let url = format!("{}/book?token_id={}", self.config.clob_url, token_id);
         let response = reqwest::get(&url)
             .await
             .map_err(|e| PolymarketError::Network(e.to_string()))?;
@@ -719,7 +719,7 @@ impl Polymarket {
     ) -> Result<Vec<String>, PolymarketError> {
         self.rate_limit().await;
 
-        let url = format!("{}/simplified-markets", CLOB_URL);
+        let url = format!("{}/simplified-markets", self.config.clob_url);
         let response = reqwest::get(&url)
             .await
             .map_err(|e| PolymarketError::Network(e.to_string()))?;


### PR DESCRIPTION
## Summary

Four sites in `engine/exchanges/polymarket/src/exchange.rs` hardcoded the production `CLOB_URL` constant instead of `self.config.clob_url`, silently ignoring `PolymarketConfig::with_clob_url(...)` for those endpoints.

| Site | Endpoint | Status before | Status after |
|---|---|---|---|
| `Polymarket::get_orderbook` (line 591) | `GET /book?token_id=…` | hardcoded | uses config |
| `Polymarket::fetch_token_ids` (line 722) | `GET /simplified-markets` | hardcoded | uses config |
| `init_sdk_state_inner` (line 325) | `SdkClient::new(URL, …)` | hardcoded | uses config |
| `recover_api_credentials` (line 427) | `SdkClient::new(URL, …)` | hardcoded | uses config |

Inconsistent with `fetch_orderbooks_batch`, `/time`, and `/books` paths in the same file, which already read `self.config.clob_url` correctly.

## Why this matters

Blocked test/staging URL redirection. Anyone trying to point the Polymarket exchange at a mock server, a staging CLOB, or a regional mirror would get 404s from production instead of their configured server.

Discovered by an SDK comparison bench harness that pointed `Exchange("polymarket", {"clob_url": "http://127.0.0.1:9999"})` at a local mock and got `market not found: no orderbook for token: …` instead of the mock's response.

## Diff shape

5 line changes total:
- 1 import line (drop unused `CLOB_URL` import)
- 4 string-format / function-arg replacements

No behavior change for callers that don't override `clob_url` (default still resolves to `https://clob.polymarket.com`).

## Test plan

- [x] `cargo test -p px-exchange-polymarket --lib` — 37/37 pass
- [ ] Reviewer: confirm no production credentials are baked into mock responses if you run the comparison harness
- [ ] Reviewer: spot-check the four diff sites against `fetch_orderbooks_batch` for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)