### PR TITLE
feat(bench): surface Rust CPU instructions + heap allocations in README

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: taiki-e/install-action@v2
         with:
-          tool: just,cargo-codspeed
+          tool: just,cargo-codspeed,iai-callgrind-runner@0.14
 
       - name: Set up .venv with build + bench tooling
         run: |
@@ -134,6 +134,16 @@ jobs:
       # build above; only the harness re-runs.
       - name: Refresh local criterion JSON for README render
         run: cargo bench -p px-bench-comparative -- --warm-up-time 1 --measurement-time 2
+
+      # iai-callgrind drives valgrind (cachegrind + DHAT) and writes
+      # per-bench JSON summaries to `target/iai/...` that the render
+      # step turns into the CPU-instructions and heap-allocation rows of
+      # the Rust comparison table. The `iai` feature gate keeps this
+      # bench out of plain `cargo bench` so non-Linux dev (macOS) keeps
+      # working with just the criterion walltime harness.
+      - name: Codspeed-equivalent Rust CPU + memory via iai-callgrind
+        run: cargo bench -p px-bench-comparative --features iai --bench parse_polymarket_book_iai
+        continue-on-error: true
 
       - name: Codspeed — Python walltime (Polymarket)
         uses: CodSpeedHQ/action@v3

--- a/README.md
+++ b/README.md
@@ -31,33 +31,37 @@ OpenPX vs the official native SDKs, head-to-head against live 5/15-min BTC marke
 
 ### Rust core
 
-_Kalshi has no upstream Rust SDK — OpenPX is the only Rust client that supports it._
+_Kalshi has no upstream Rust SDK — OpenPX is the only Rust client that supports it. Walltime from criterion; CPU instructions and heap allocations from valgrind via iai-callgrind (deterministic, hardware-agnostic — same instruments Codspeed uses)._
 
-| Operation | OpenPX | polymarket_client_sdk_v2 | Speedup |
-|---|---:|---:|---:|
-| Parse Polymarket book (5-min BTC fixture) | 4.38 µs | 5.84 µs | **1.33×** |
+| Operation | Metric | OpenPX | polymarket_client_sdk_v2 | Speedup |
+|---|---|---:|---:|---:|
+| Parse Polymarket book (5-min BTC fixture) | Walltime | 4.38 µs | 5.84 µs | **1.33×** |
 
 ### Python SDK
 
-| Operation | OpenPX | py-clob-client | Speedup |
-|---|---:|---:|---:|
-| Polymarket fetch_orderbook (5-min BTC, live) | 276.21 ms | 362.99 ms | **1.31×** |
+_Walltime over real, unauthenticated HTTP round-trips. CPU instructions and heap allocations aren't reported per-language in the README — Codspeed only exposes those instruments for compiled-language harnesses (see Rust above and the dashboard for trends)._
 
-| Operation | OpenPX | kalshi-python | Speedup |
-|---|---:|---:|---:|
-| Kalshi fetch_orderbook (15-min BTC, live) | 363.96 ms | 366.15 ms | **1.01×** |
+| Operation | Metric | OpenPX | py-clob-client | Speedup |
+|---|---|---:|---:|---:|
+| Polymarket fetch_orderbook (5-min BTC, live) | Walltime | 276.21 ms | 362.99 ms | **1.31×** |
+
+| Operation | Metric | OpenPX | kalshi-python | Speedup |
+|---|---|---:|---:|---:|
+| Kalshi fetch_orderbook (15-min BTC, live) | Walltime | 363.96 ms | 366.15 ms | **1.01×** |
 
 ### TypeScript SDK
 
-| Operation | OpenPX | @polymarket/clob-client | Speedup |
-|---|---:|---:|---:|
-| Polymarket fetch_orderbook (5-min BTC, live) | 261.89 ms | 278.14 ms | **1.06×** |
+_Walltime over real, unauthenticated HTTP round-trips._
 
-| Operation | OpenPX | kalshi-typescript | Speedup |
-|---|---:|---:|---:|
-| Kalshi fetch_orderbook (15-min BTC, live) | 370.13 ms | 385.13 ms | **1.04×** |
+| Operation | Metric | OpenPX | @polymarket/clob-client | Speedup |
+|---|---|---:|---:|---:|
+| Polymarket fetch_orderbook (5-min BTC, live) | Walltime | 261.89 ms | 278.14 ms | **1.06×** |
 
-<sub>Last updated: 2026-05-05 · Methodology: [benches/comparative/README.md](benches/comparative/README.md) · Raw data: [benches/comparative/results/](benches/comparative/results/)</sub>
+| Operation | Metric | OpenPX | kalshi-typescript | Speedup |
+|---|---|---:|---:|---:|
+| Kalshi fetch_orderbook (15-min BTC, live) | Walltime | 370.13 ms | 385.13 ms | **1.04×** |
+
+<sub>Last updated: 2026-05-12 · Methodology: [benches/comparative/README.md](benches/comparative/README.md) · Raw data: [benches/comparative/results/](benches/comparative/results/)</sub>
 <!-- BENCH:END -->
 
 ## Quick Start

--- a/benches/comparative/README.md
+++ b/benches/comparative/README.md
@@ -64,10 +64,22 @@ CPU simulation and memory are Linux-only (Valgrind / eBPF); they run
 under Codspeed's `codspeed-macro` runner. Walltime runs everywhere
 including local laptops via `cargo bench` / `pytest` / `node bench.mjs`.
 
-The README block surfaces the walltime numbers from each harness's
-local JSON output (criterion / pytest-benchmark / tinybench); the
-Codspeed dashboard surfaces CPU instructions, allocations, and per-PR
-deltas across all three modes.
+The README block surfaces all three Rust modes plus walltime for the
+SDK harnesses:
+
+- **Rust walltime** — `cargo bench` (criterion local JSON)
+- **Rust CPU instructions** — `cargo bench --features iai` runs
+  `parse_polymarket_book_iai.rs` under valgrind/cachegrind; the
+  `Ir` cost lands in `target/iai/.../summary.json`.
+- **Rust heap allocations** — same iai-callgrind run, with DHAT
+  attached as a second valgrind tool; `total_bytes` lands in the same
+  summary file.
+- **Python / TS walltime** — pytest-benchmark / tinybench local JSON.
+
+The Codspeed dashboard surfaces the same three Rust modes plus per-PR
+deltas. Numbers should agree to within a few percent between the iai
+local JSON and Codspeed's simulation/memory reports — both use the
+same valgrind tools.
 
 ### Why the workflow runs each harness twice
 
@@ -109,6 +121,11 @@ cargo codspeed run -p px-bench-comparative --measurement-mode simulation
 cargo codspeed run -p px-bench-comparative --measurement-mode memory
 cargo codspeed run -p px-bench-comparative --measurement-mode walltime
 pytest --codspeed benches/comparative/python/
+
+# Or produce the Rust CPU-instruction + heap-allocation summaries that
+# feed the README (Linux only — requires valgrind + iai-callgrind-runner):
+cargo install iai-callgrind-runner@0.14
+cargo bench -p px-bench-comparative --features iai --bench parse_polymarket_book_iai
 ```
 
 ## Methodology details

--- a/benches/comparative/rust/Cargo.toml
+++ b/benches/comparative/rust/Cargo.toml
@@ -6,6 +6,13 @@ license.workspace = true
 publish = false
 description = "OpenPX-vs-official-SDK head-to-head benchmarks. Not part of the published surface."
 
+[features]
+# Opt-in for the iai-callgrind harness (CPU instructions + DHAT heap
+# allocations). Valgrind-only, so Linux-only at runtime. Plain
+# `cargo bench` on macOS just runs the criterion walltime bench; CI
+# passes `--features iai` to also run the iai sibling.
+iai = []
+
 [lib]
 path = "src/lib.rs"
 bench = false
@@ -24,9 +31,20 @@ polymarket_client_sdk_v2 = { version = "=0.6.0-canary.1", features = ["clob"] }
 # plain `cargo bench` it falls through to vanilla criterion timings, so
 # local runs still work without the Codspeed CLI installed.
 codspeed-criterion-compat = "2"
+# iai-callgrind drives valgrind (cachegrind + DHAT) and writes per-bench
+# JSON summaries to `target/iai/...`. The render step reads `Ir`
+# (instruction count) and `total_bytes` (heap allocations) into the
+# README's Rust table. Compiles on any platform; only executes under
+# Linux/valgrind, gated by the `iai` feature on the bench below.
+iai-callgrind = "0.14"
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [[bench]]
 name = "parse_polymarket_book"
 harness = false
+
+[[bench]]
+name = "parse_polymarket_book_iai"
+harness = false
+required-features = ["iai"]

--- a/benches/comparative/rust/benches/parse_polymarket_book_iai.rs
+++ b/benches/comparative/rust/benches/parse_polymarket_book_iai.rs
@@ -72,8 +72,7 @@ fn openpx() -> (usize, usize) {
 #[library_benchmark]
 fn polymarket_sdk() -> (usize, usize) {
     let bytes = fixture_bytes();
-    let book: OrderBookSummaryResponse =
-        serde_json::from_slice(black_box(&bytes)).expect("decode");
+    let book: OrderBookSummaryResponse = serde_json::from_slice(black_box(&bytes)).expect("decode");
     black_box((book.bids.len(), book.asks.len()))
 }
 

--- a/benches/comparative/rust/benches/parse_polymarket_book_iai.rs
+++ b/benches/comparative/rust/benches/parse_polymarket_book_iai.rs
@@ -1,0 +1,87 @@
+//! OpenPX vs `polymarket_client_sdk_v2` — CPU-instruction (cachegrind)
+//! and heap-allocation (DHAT) comparison on the same Polymarket
+//! orderbook fixture used by `parse_polymarket_book.rs`.
+//!
+//! Sibling to the criterion bench: same fixture, same two contestants,
+//! different instruments. Criterion measures wall-clock. This harness
+//! runs under valgrind and produces deterministic
+//!
+//!  - **CPU instructions** (`Ir`) — cachegrind's executed-instruction
+//!    count. Hardware-agnostic, <1% variance. Mirrors Codspeed's
+//!    `--measurement-mode simulation`.
+//!  - **Heap allocations** (`total_bytes`) — DHAT's cumulative bytes
+//!    allocated on the hot path. Mirrors Codspeed's `--measurement-mode
+//!    memory`.
+//!
+//! Both summaries land in `target/iai/.../summary.json`; the README
+//! render script reads them to fill the CPU + memory rows of the Rust
+//! comparison table.
+//!
+//! Linux-only — Valgrind/DHAT don't run on macOS. The
+//! `required-features = ["iai"]` gate in `Cargo.toml` keeps this bench
+//! out of local mac `cargo bench` runs.
+
+use iai_callgrind::{
+    black_box, library_benchmark, library_benchmark_group, main, LibraryBenchmarkConfig, Tool,
+    ValgrindTool,
+};
+use polymarket_client_sdk_v2::clob::types::response::OrderBookSummaryResponse;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+struct OpenPxBook {
+    asset_id: String,
+    market: String,
+    timestamp: String,
+    bids: Vec<OpenPxLevel>,
+    asks: Vec<OpenPxLevel>,
+    #[serde(default)]
+    hash: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[allow(dead_code)]
+struct OpenPxLevel {
+    price: String,
+    size: String,
+}
+
+fn fixture_bytes() -> Vec<u8> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../fixtures/polymarket_book.json");
+    std::fs::read(&path).unwrap_or_else(|e| {
+        panic!(
+            "missing fixture {}: {e}\nRun `python3 tools/capture_bench_fixtures.py` first.",
+            path.display()
+        )
+    })
+}
+
+#[library_benchmark]
+fn openpx() -> (usize, usize) {
+    let bytes = fixture_bytes();
+    let s = std::str::from_utf8(black_box(&bytes)).unwrap();
+    let frame = px_core::decode_frame::<OpenPxBook>(s).expect("decode");
+    match frame {
+        px_core::WsFrame::Single(book) => black_box((book.bids.len(), book.asks.len())),
+        px_core::WsFrame::Array(_) => unreachable!("single object fixture"),
+    }
+}
+
+#[library_benchmark]
+fn polymarket_sdk() -> (usize, usize) {
+    let bytes = fixture_bytes();
+    let book: OrderBookSummaryResponse =
+        serde_json::from_slice(black_box(&bytes)).expect("decode");
+    black_box((book.bids.len(), book.asks.len()))
+}
+
+library_benchmark_group!(
+    name = parse_polymarket_book;
+    config = LibraryBenchmarkConfig::default()
+        .tool(Tool::new(ValgrindTool::DHAT));
+    benchmarks = openpx, polymarket_sdk
+);
+
+main!(library_benchmark_groups = parse_polymarket_book);

--- a/justfile
+++ b/justfile
@@ -110,6 +110,11 @@ bench-compare:
     mkdir -p benches/comparative/results
     {{venv}}/bin/python tools/capture_bench_fixtures.py
     cargo bench -p px-bench-comparative
+    # iai-callgrind drives valgrind (Linux-only) for CPU instructions +
+    # DHAT heap allocations. The `-` prefix swallows failures so macOS
+    # devs still get the rest of the suite; CI re-runs this under Linux
+    # and the README populates with real numbers there.
+    -cargo bench -p px-bench-comparative --features iai --bench parse_polymarket_book_iai
     -{{venv}}/bin/pytest benches/comparative/python/bench_polymarket.py \
         --benchmark-only \
         --benchmark-json=benches/comparative/results/python_polymarket.json -q

--- a/tools/render_bench_readme.py
+++ b/tools/render_bench_readme.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 """Render comparative-benchmark JSON into the README's BENCH block.
 
-The bench suite runs three harnesses, each producing a different
-JSON shape that we read here:
+The bench suite runs four harnesses, each producing a different JSON
+shape that we read here:
 
-  - Rust (criterion / codspeed-criterion-compat):
+  - Rust walltime (criterion / codspeed-criterion-compat):
       target/criterion/<group>/<id>/new/estimates.json
+  - Rust CPU + memory (iai-callgrind, valgrind + DHAT):
+      target/iai/px-bench-comparative/parse_polymarket_book_iai/
+        parse_polymarket_book/<id>/summary.json
   - Python (pytest-benchmark / pytest-codspeed):
       benches/comparative/results/python_polymarket.json
       benches/comparative/results/python_kalshi.json
@@ -31,11 +34,15 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
 README = ROOT / "README.md"
 RESULTS_DIR = ROOT / "benches" / "comparative" / "results"
 CRITERION_DIR = ROOT / "target" / "criterion"
+IAI_DIR = (
+    ROOT / "target" / "iai" / "px-bench-comparative" / "parse_polymarket_book_iai"
+)
 
 START_MARKER = "<!-- BENCH:START -->"
 END_MARKER = "<!-- BENCH:END -->"
@@ -60,10 +67,38 @@ def fmt_ns(ns: float | None) -> str:
     return f"{ns / 1_000_000_000:.2f} s"
 
 
-def fmt_speedup(openpx_ns: float | None, other_ns: float | None) -> str:
-    if openpx_ns is None or other_ns is None or openpx_ns <= 0:
+def fmt_count(n: float | None) -> str:
+    """Integer-ish count: instruction counts, allocation counts."""
+    if n is None:
         return "—"
-    ratio = other_ns / openpx_ns
+    if n < 1_000:
+        return f"{n:,.0f}"
+    if n < 1_000_000:
+        return f"{n / 1_000:.2f}k"
+    if n < 1_000_000_000:
+        return f"{n / 1_000_000:.2f}M"
+    return f"{n / 1_000_000_000:.2f}B"
+
+
+def fmt_bytes(b: float | None) -> str:
+    if b is None:
+        return "—"
+    if b < 1024:
+        return f"{b:,.0f} B"
+    if b < 1024**2:
+        return f"{b / 1024:.2f} KiB"
+    if b < 1024**3:
+        return f"{b / 1024**2:.2f} MiB"
+    return f"{b / 1024**3:.2f} GiB"
+
+
+def fmt_speedup(openpx_v: float | None, other_v: float | None) -> str:
+    """Speedup ratio. Works for any metric where lower-is-better
+    (walltime, instructions, bytes allocated). Ratio = other / openpx;
+    >1 means OpenPX is faster/leaner. Bolded when OpenPX wins."""
+    if openpx_v is None or other_v is None or openpx_v <= 0:
+        return "—"
+    ratio = other_v / openpx_v
     return f"**{ratio:.2f}×**" if ratio >= 1.0 else f"{ratio:.2f}×"
 
 
@@ -81,6 +116,57 @@ def _criterion_estimate(group: str, function_id: str) -> float | None:
         return float(json.loads(path.read_text())["mean"]["point_estimate"])
     except (KeyError, json.JSONDecodeError, ValueError):
         return None
+
+
+def _walk_for_key(node: Any, key: str) -> Any:
+    """Depth-first walk through a JSON tree returning the first value
+    found under `key`. iai-callgrind's summary schema has shifted across
+    minor versions; this tree walker is intentionally schema-agnostic so
+    a version bump won't silently zero out the README rows. Returns the
+    raw value (int / float / str / dict) — callers narrow further."""
+    if isinstance(node, dict):
+        if key in node:
+            return node[key]
+        for v in node.values():
+            found = _walk_for_key(v, key)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for v in node:
+            found = _walk_for_key(v, key)
+            if found is not None:
+                return found
+    return None
+
+
+def _iai_metric(function_id: str, metric: str) -> float | None:
+    """Read one metric from iai-callgrind's per-bench summary.json.
+
+    Supported metrics:
+      - "Ir"          → cachegrind instruction count (CPU simulation)
+      - "total_bytes" → DHAT cumulative bytes allocated (memory)
+
+    iai-callgrind nests the actual count under various keys depending on
+    the version (`new`, `count`, raw int). We accept any of those so the
+    parser survives runner upgrades."""
+    path = IAI_DIR / "parse_polymarket_book" / function_id / "summary.json"
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return None
+    raw = _walk_for_key(payload, metric)
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, dict):
+        for k in ("new", "count", "value", "total"):
+            v = raw.get(k)
+            if isinstance(v, (int, float)):
+                return float(v)
+    return None
 
 
 def _pytest_benchmarks(filename: str) -> dict[str, float]:
@@ -127,37 +213,58 @@ def _tinybench_results(filename: str) -> dict[str, float]:
 @dataclass(frozen=True)
 class Row:
     operation: str
-    openpx_ns: float | None
-    other_ns: float | None
+    metric: str
+    openpx: float | None
+    other: float | None
+    formatter: Any  # callable: float | None -> str
 
 
 def render_table(other_label: str, rows: list[Row]) -> str:
-    """Three-column table: Operation | OpenPX | <other> | Speedup.
+    """Five-column table: Operation | Metric | OpenPX | <other> | Speedup.
 
-    Drops rows where both sides are missing so an empty section
-    collapses cleanly (the section header is added by the caller).
+    Each row picks its own formatter (ns / instruction count / bytes)
+    so the Rust table can mix walltime, CPU instructions, and heap
+    allocations under one header. Drops rows where both sides are
+    missing so an empty section collapses cleanly.
     """
-    rows = [r for r in rows if r.openpx_ns is not None or r.other_ns is not None]
+    rows = [r for r in rows if r.openpx is not None or r.other is not None]
     if not rows:
         return ""
     out = [
-        f"| Operation | OpenPX | {other_label} | Speedup |",
-        "|---|---:|---:|---:|",
+        f"| Operation | Metric | OpenPX | {other_label} | Speedup |",
+        "|---|---|---:|---:|---:|",
     ]
     for r in rows:
         out.append(
-            f"| {r.operation} | {fmt_ns(r.openpx_ns)} | {fmt_ns(r.other_ns)} | "
-            f"{fmt_speedup(r.openpx_ns, r.other_ns)} |"
+            f"| {r.operation} | {r.metric} | {r.formatter(r.openpx)} | "
+            f"{r.formatter(r.other)} | {fmt_speedup(r.openpx, r.other)} |"
         )
     return "\n".join(out)
 
 
 def render_rust_section() -> str:
+    op = "Parse Polymarket book (5-min BTC fixture)"
     rows = [
         Row(
-            "Parse Polymarket book (5-min BTC fixture)",
+            op,
+            "Walltime",
             _criterion_estimate("parse_polymarket_book", "openpx"),
             _criterion_estimate("parse_polymarket_book", "polymarket_sdk"),
+            fmt_ns,
+        ),
+        Row(
+            op,
+            "CPU instructions (cachegrind)",
+            _iai_metric("openpx", "Ir"),
+            _iai_metric("polymarket_sdk", "Ir"),
+            fmt_count,
+        ),
+        Row(
+            op,
+            "Heap allocations (DHAT)",
+            _iai_metric("openpx", "total_bytes"),
+            _iai_metric("polymarket_sdk", "total_bytes"),
+            fmt_bytes,
         ),
     ]
     table = render_table("polymarket_client_sdk_v2", rows)
@@ -166,7 +273,9 @@ def render_rust_section() -> str:
     return (
         "### Rust core\n\n"
         "_Kalshi has no upstream Rust SDK — OpenPX is the only Rust client "
-        "that supports it._\n\n" + table
+        "that supports it. Walltime from criterion; CPU instructions and "
+        "heap allocations from valgrind via iai-callgrind (deterministic, "
+        "hardware-agnostic — same instruments Codspeed uses)._\n\n" + table
     )
 
 
@@ -181,8 +290,10 @@ def render_python_section() -> str:
         [
             Row(
                 "Polymarket fetch_orderbook (5-min BTC, live)",
+                "Walltime",
                 poly.get("test_openpx_fetch_polymarket_book"),
                 poly.get("test_pyclob_fetch_polymarket_book"),
+                fmt_ns,
             ),
         ],
     )
@@ -194,8 +305,10 @@ def render_python_section() -> str:
         [
             Row(
                 "Kalshi fetch_orderbook (15-min BTC, live)",
+                "Walltime",
                 kalshi.get("test_openpx_fetch_kalshi_book"),
                 kalshi.get("test_kalshi_python_fetch_kalshi_book"),
+                fmt_ns,
             ),
         ],
     )
@@ -204,7 +317,14 @@ def render_python_section() -> str:
 
     if not sections:
         return ""
-    return "### Python SDK\n\n" + "\n\n".join(sections)
+    return (
+        "### Python SDK\n\n"
+        "_Walltime over real, unauthenticated HTTP round-trips. CPU "
+        "instructions and heap allocations aren't reported per-language "
+        "in the README — Codspeed only exposes those instruments for "
+        "compiled-language harnesses (see Rust above and the dashboard "
+        "for trends)._\n\n" + "\n\n".join(sections)
+    )
 
 
 def render_typescript_section() -> str:
@@ -218,8 +338,10 @@ def render_typescript_section() -> str:
         [
             Row(
                 "Polymarket fetch_orderbook (5-min BTC, live)",
+                "Walltime",
                 poly.get("openpx::polymarket::fetch_orderbook"),
                 poly.get("polymarket-clob-client::fetch_orderbook"),
+                fmt_ns,
             ),
         ],
     )
@@ -243,8 +365,10 @@ def render_typescript_section() -> str:
         [
             Row(
                 "Kalshi fetch_orderbook (15-min BTC, live)",
+                "Walltime",
                 kalshi.get("openpx::kalshi::fetch_orderbook"),
                 kalshi_other,
+                fmt_ns,
             ),
         ],
     )
@@ -253,7 +377,11 @@ def render_typescript_section() -> str:
 
     if not sections:
         return ""
-    return "### TypeScript SDK\n\n" + "\n\n".join(sections)
+    return (
+        "### TypeScript SDK\n\n"
+        "_Walltime over real, unauthenticated HTTP round-trips._\n\n"
+        + "\n\n".join(sections)
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Codspeed already captures all three modes for Rust (simulation, memory, walltime), but `cargo codspeed run` pipes those measurements straight to the dashboard without writing local JSON — so only walltime made it into the README. Adds an iai-callgrind sibling bench that drives the same valgrind tools locally (cachegrind for Ir, DHAT for total_bytes) and splices both into the Rust row alongside criterion's walltime.

Tables now have a Metric column so every row states what it's reporting; Python and TypeScript stay walltime-only (Codspeed exposes the other instruments only for compiled-language harnesses).

## What

<!-- Brief description of the change -->

## Why

<!-- Motivation: bug fix, feature, performance, etc. -->

## How

<!-- Implementation approach. Call out any non-obvious decisions. -->

## Testing

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace -- -D warnings` passes
- [ ] `cargo fmt --all --check` passes
- [ ] New tests added for new functionality
- [ ] No new dependencies added (or justified in description)

## Breaking Changes

<!-- List any breaking changes, or "None" -->
