### PR TITLE
docs(bench): tighten iai bench header comment

### DIFF
--- a/benches/comparative/rust/benches/parse_polymarket_book_iai.rs
+++ b/benches/comparative/rust/benches/parse_polymarket_book_iai.rs
@@ -3,8 +3,8 @@
 //! orderbook fixture used by `parse_polymarket_book.rs`.
 //!
 //! Sibling to the criterion bench: same fixture, same two contestants,
-//! different instruments. Criterion measures wall-clock. This harness
-//! runs under valgrind and produces deterministic
+//! different instruments. Criterion measures wall-clock time. This
+//! harness runs under valgrind and produces two deterministic counters:
 //!
 //!  - **CPU instructions** (`Ir`) — cachegrind's executed-instruction
 //!    count. Hardware-agnostic, <1% variance. Mirrors Codspeed's


### PR DESCRIPTION
## Summary

Tiny doc-only fix to `parse_polymarket_book_iai.rs` header — completes the dangling "produces deterministic" sentence before the bullet list. Two characters changed.

## Why

Trivial readability nit. Also useful as a low-risk merge to confirm `bench.yml` can pick up a `codspeed-macro` runner now that PR #101's queued run has been sitting for over an hour.

## Files

- \`benches/comparative/rust/benches/parse_polymarket_book_iai.rs\` — 2-line wording fix

## Review focus

Should be a one-glance approve. No code paths touched, no tests affected.

## Test plan

- [ ] CI passes (Format / Clippy / Test / Check / SDK Sync / Version Sync / Benchmarks smoke)
- [ ] On merge, watch \`bench.yml\` — if it picks up a runner this time, the README's iai rows should populate. If it stays queued, that confirms the runner-availability issue is separate from any code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)