### PR TITLE
ci(bench): npm install in sdks/typescript before node-build

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -74,6 +74,12 @@ jobs:
           .venv/bin/pip install py-clob-client || true
           .venv/bin/pip install kalshi-python cryptography || true
 
+      # `just node-build` runs `npm run build` which invokes `napi build`
+      # via @napi-rs/cli — a devDependency of sdks/typescript. Install
+      # node_modules first so the binary is on PATH; otherwise the recipe
+      # fails with `sh: 1: napi: not found`.
+      - run: cd sdks/typescript && npm install
+
       - name: Build OpenPX SDKs against current Rust core
         run: just venv="$(pwd)/.venv" python-build node-build
 


### PR DESCRIPTION
## Summary
- Bench workflow fails with \`sh: 1: napi: not found\` because \`just node-build\` runs \`npm run build\` → \`napi build --release\`, but \`@napi-rs/cli\` (a devDependency) is only on PATH after \`npm install\`.
- \`ci.yml\` already does this before \`just node-build\`; \`bench.yml\` was missing the step. Run from #105: https://github.com/openpx-trade/openpx/actions/runs/25815559585

## Test plan
- [ ] Bench workflow on this PR's merge to main reaches \`Build OpenPX SDKs against current Rust core\` without \`napi: not found\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)