### PR TITLE
fix(bench): bump codspeed-criterion-compat to v4, harden CodSpeed steps

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -129,18 +129,21 @@ jobs:
         with:
           mode: walltime
           run: cargo codspeed run -p px-bench-comparative
+        continue-on-error: true
 
       - name: CodSpeed — Python walltime (Polymarket)
         uses: CodSpeedHQ/action@v4
         with:
           mode: walltime
           run: .venv/bin/pytest benches/comparative/python/bench_polymarket.py --codspeed -q
+        continue-on-error: true
 
       - name: CodSpeed — Python walltime (Kalshi)
         uses: CodSpeedHQ/action@v4
         with:
           mode: walltime
           run: .venv/bin/pytest benches/comparative/python/bench_kalshi.py --codspeed -q
+        continue-on-error: true
 
       - name: CodSpeed — TypeScript walltime (Polymarket)
         uses: CodSpeedHQ/action@v4
@@ -149,6 +152,7 @@ jobs:
           run: |
             cd benches/comparative/typescript
             node bench_polymarket.mjs
+        continue-on-error: true
 
       - name: CodSpeed — TypeScript walltime (Kalshi)
         uses: CodSpeedHQ/action@v4
@@ -157,6 +161,7 @@ jobs:
           run: |
             cd benches/comparative/typescript
             node bench_kalshi.mjs
+        continue-on-error: true
 
       - name: Commit refreshed fixtures
         run: |

--- a/benches/comparative/rust/Cargo.toml
+++ b/benches/comparative/rust/Cargo.toml
@@ -30,7 +30,7 @@ polymarket_client_sdk_v2 = { version = "=0.6.0-canary.1", features = ["clob"] }
 # the harness emits cycle-count / memory / walltime measurements; under
 # plain `cargo bench` it falls through to vanilla criterion timings, so
 # local runs still work without the Codspeed CLI installed.
-codspeed-criterion-compat = "2"
+codspeed-criterion-compat = "4"
 # iai-callgrind drives valgrind (cachegrind + DHAT) and writes per-bench
 # JSON summaries to `target/iai/...`. The render step reads `Ir`
 # (instruction count) and `total_bytes` (heap allocations) into the


### PR DESCRIPTION
## Summary

- Bump `codspeed-criterion-compat` from `"2"` to `"4"` to match the installed `cargo-codspeed v4.6.0` on the `codspeed-macro` runner.
- Add `continue-on-error: true` to every CodSpeed-wrapped step so one mode failing doesn't cascade-skip the rest of the suite.

## Why

First post-merge run of `bench.yml` on `main` (after #108) failed at `CodSpeed — Rust walltime` with:

> Failed to collect walltime results. This may be due to version incompatibility. Ensure that your compat layer (codspeed-criterion-compat, codspeed-bencher-compat, or codspeed-divan-compat) has the same major version as cargo-codspeed (currently v4.6.0).

The compat-layer pin was last touched when the bench crate was added and never tracked the action upgrade to v4. `cargo update -p codspeed-criterion-compat` resolves the new `"4"` constraint to v4.6.0 exactly. `cargo check -p px-bench-comparative --benches` is green locally.

Separately, that walltime failure cascade-skipped five downstream steps (Python ×2, TypeScript ×2, fixture commit) because they had no `continue-on-error`. Bench data is best-effort dashboard data — one mode failing shouldn't drop the rest of the suite. Wrapping every CodSpeed step in `continue-on-error: true` isolates failures.

## Test plan

- [ ] `cargo check -p px-bench-comparative --benches` — green locally, will gate in CI.
- [ ] Merge triggers `bench.yml` on `main`; verify Rust walltime now passes and Python + TS steps run end-to-end.
- [ ] Verify the resulting CodSpeed run contains comparative bench URIs across all three runner modes (`Simulation`, `Memory`, `WallTime`) for Rust and `WallTime` for Python + TS.
- [ ] Once data lands, kick `/refresh-bench-readme` to populate the README block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)