### PR TITLE
ci(release): install pyyaml so sync-release-pr-docs can regenerate specs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install Python deps for doc generators
+        run: pip install pyyaml
       - name: Regenerate openapi + asyncapi
         run: |
           python3 tools/gen_openapi.py


### PR DESCRIPTION
## Summary

Add `pip install pyyaml` to the `sync-release-pr-docs` job so `tools/gen_openapi.py` and `tools/gen_asyncapi.py` can actually run.

## Why

The release-please PR #92 (0.3.1) is currently failing the `Sync derived docs on release PR` job with:

```
ModuleNotFoundError: No module named 'yaml'
  File "/home/runner/work/openpx/openpx/tools/gen_openapi.py", line 26, in <module>
    import yaml
```

Both `gen_openapi.py` and `gen_asyncapi.py` `import yaml`, but the workflow only calls `actions/setup-python@v5` — there's no PyYAML install step, so the regenerator immediately crashes.

Unrelated to the bench / CodSpeed work in #108 / #109; just surfaced as a side effect of those merges retriggering release.yml.

## Test plan

- [ ] Merge → next push to the release-please branch reruns the job; PyYAML installs; the regenerator either commits synced specs or reports "no drift".
- [ ] Confirm `Sync derived docs on release PR` is green on PR #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)