### PR TITLE
style(bench): satisfy cargo fmt on hot_path orderbook_ops

### DIFF
--- a/benches/comparative/rust/benches/hot_path.rs
+++ b/benches/comparative/rust/benches/hot_path.rs
@@ -229,12 +229,8 @@ fn bench_apply_updates(c: &mut Criterion) {
 fn bench_orderbook_ops(c: &mut Criterion) {
     let book = make_book_from_fixture();
     let mut group = c.benchmark_group("orderbook_ops");
-    group.bench_function("openpx_best_bid", |b| {
-        b.iter(|| black_box(book.best_bid()))
-    });
-    group.bench_function("openpx_best_ask", |b| {
-        b.iter(|| black_box(book.best_ask()))
-    });
+    group.bench_function("openpx_best_bid", |b| b.iter(|| black_box(book.best_bid())));
+    group.bench_function("openpx_best_ask", |b| b.iter(|| black_box(book.best_ask())));
     group.bench_function("openpx_spread", |b| b.iter(|| black_box(book.spread())));
     group.bench_function("openpx_mid_price", |b| {
         b.iter(|| black_box(book.mid_price()))


### PR DESCRIPTION
## Summary
- Collapse `openpx_best_bid` / `openpx_best_ask` `bench_function` calls in `benches/comparative/rust/benches/hot_path.rs` to single-line closures so `cargo fmt --all --check` passes.
- This is the **only** diff `cargo fmt` produces on `main` today; once merged, release-please PR #92 (chore(main): release 0.3.1) will sync and its failing **Format** job goes green.

## Why
The Format check on PR #92 is the only blocker keeping us from rolling out 0.3.1. The exact diff cargo fmt is asking for on the release-please branch matches the diff it asks for on `main`, so the right place to fix is `main` — release-please regenerates from there.

## Scope
- One file. No behavioral or structural change.
- Bench surface unchanged: same group, same four sub-benches, same closure bodies.

## Test plan
- [x] `cargo fmt --all --check` passes locally on this branch
- [ ] CI Format job on this PR goes green
- [ ] After merge, PR #92 picks up the fix and its Format job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)